### PR TITLE
Fixes policy-related methods and removes linter warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/javascript-sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/javascript-sdk",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "ForgeRock JavaScript SDK",
   "main": "./lib/",
   "module": "./lib-esm/",

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -20,11 +20,15 @@ abstract class Auth {
     const url = this.constructUrl(serverConfig, realmPath, tree);
     const init = this.configureRequest(previousStep);
     const res = await withTimeout(fetch(url, init), serverConfig.timeout);
-    const json = await this.getResponseJson(res);
+    const json = await this.getResponseJson<Step>(res);
     return json;
   }
 
-  private static constructUrl(serverConfig: ServerConfig, realmPath?: string, tree?: string) {
+  private static constructUrl(
+    serverConfig: ServerConfig,
+    realmPath?: string,
+    tree?: string,
+  ): string {
     const realmUrlPath = getRealmUrlPath(realmPath);
     const query = tree ? `?authIndexType=service&authIndexValue=${tree}` : '';
     const path = `json/${realmUrlPath}/authenticate${query}`;
@@ -32,7 +36,7 @@ abstract class Auth {
     return url;
   }
 
-  private static configureRequest(step?: Step) {
+  private static configureRequest(step?: Step): RequestInit {
     const init: RequestInit = {
       body: step ? JSON.stringify(step) : undefined,
       credentials: 'include',
@@ -46,7 +50,7 @@ abstract class Auth {
     return init;
   }
 
-  private static async getResponseJson(res: Response) {
+  private static async getResponseJson<T>(res: Response): Promise<T> {
     const contentType = res.headers.get('content-type');
     const isJson = contentType && contentType.indexOf('application/json') > -1;
     const json = isJson ? await res.json() : undefined;

--- a/src/auth/interfaces.ts
+++ b/src/auth/interfaces.ts
@@ -44,7 +44,7 @@ interface PolicyRequirement {
 }
 
 interface PolicyParams {
-  [key: string]: any;
+  [key: string]: unknown;
   disallowedFields: string;
   duplicateValue: string;
   forbiddenChars: string;
@@ -69,7 +69,7 @@ interface Callback {
  */
 interface NameValue {
   name: string;
-  value: any;
+  value: unknown;
 }
 
 export {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -26,7 +26,7 @@ abstract class Config {
    *
    * @param options The options to use as defaults
    */
-  public static set(options: ConfigOptions) {
+  public static set(options: ConfigOptions): void {
     if (!this.isValid(options)) {
       throw new Error('Configuration is invalid');
     }
@@ -54,11 +54,11 @@ abstract class Config {
     return merged as ValidConfigOptions;
   }
 
-  private static isValid(options: ConfigOptions) {
-    return options && options.serverConfig;
+  private static isValid(options: ConfigOptions): boolean {
+    return !!(options && options.serverConfig);
   }
 
-  private static validateServerConfig(serverConfig: ServerConfig) {
+  private static validateServerConfig(serverConfig: ServerConfig): void {
     if (!serverConfig.timeout) {
       serverConfig.timeout = DEFAULT_TIMEOUT;
     }

--- a/src/event/helpers.ts
+++ b/src/event/helpers.ts
@@ -1,0 +1,31 @@
+import { CallbackContainer, Listener } from './interfaces';
+
+/** @hidden */
+function add(container: CallbackContainer, type: string, listener: Listener): void {
+  container[type] = container[type] || [];
+  if (container[type].indexOf(listener) < 0) {
+    container[type].push(listener);
+  }
+}
+
+/** @hidden */
+function remove(container: CallbackContainer, type: string, listener: Listener): void {
+  if (!container[type]) {
+    return;
+  }
+  const index = container[type].indexOf(listener);
+  if (index >= 0) {
+    container[type].splice(index, 1);
+  }
+}
+
+/** @hidden */
+function clear(container: CallbackContainer, type?: string): void {
+  Object.keys(container).forEach((k: string) => {
+    if (!type || k === type) {
+      delete container[k];
+    }
+  });
+}
+
+export { add, clear, remove };

--- a/src/event/index.ts
+++ b/src/event/index.ts
@@ -1,3 +1,4 @@
+import { add, clear, remove } from './helpers';
 import { CallbackContainer, FREvent, Listener } from './interfaces';
 
 /**
@@ -12,7 +13,7 @@ class Dispatcher {
    * @param type The event type
    * @param listener The function to subscribe to events of this type
    */
-  public addEventListener(type: string, listener: Listener) {
+  public addEventListener(type: string, listener: Listener): void {
     add(this.callbacks, type, listener);
   }
 
@@ -22,7 +23,7 @@ class Dispatcher {
    * @param type The event type
    * @param listener The function to unsubscribe from events of this type
    */
-  public removeEventListener(type: string, listener: Listener) {
+  public removeEventListener(type: string, listener: Listener): void {
     remove(this.callbacks, type, listener);
   }
 
@@ -31,7 +32,7 @@ class Dispatcher {
    *
    * @param type The event type, or all event types if not specified
    */
-  public clearEventListeners(type?: string) {
+  public clearEventListeners(type?: string): void {
     clear(this.callbacks, type);
   }
 
@@ -40,7 +41,7 @@ class Dispatcher {
    *
    * @param event The event object to publish
    */
-  public dispatchEvent<T extends FREvent>(event: T) {
+  public dispatchEvent<T extends FREvent>(event: T): void {
     if (!this.callbacks[event.type]) {
       return;
     }
@@ -48,34 +49,6 @@ class Dispatcher {
       listener(event);
     }
   }
-}
-
-/** @hidden */
-function add(container: CallbackContainer, type: string, listener: Listener) {
-  container[type] = container[type] || [];
-  if (container[type].indexOf(listener) < 0) {
-    container[type].push(listener);
-  }
-}
-
-/** @hidden */
-function remove(container: CallbackContainer, type: string, listener: Listener) {
-  if (!container[type]) {
-    return;
-  }
-  const index = container[type].indexOf(listener);
-  if (index >= 0) {
-    container[type].splice(index, 1);
-  }
-}
-
-/** @hidden */
-function clear(container: CallbackContainer, type?: string) {
-  Object.keys(container).forEach((k: string) => {
-    if (!type || k === type) {
-      delete container[k];
-    }
-  });
 }
 
 export default Dispatcher;

--- a/src/fr-auth/callbacks/attribute-input-callback.test.ts
+++ b/src/fr-auth/callbacks/attribute-input-callback.test.ts
@@ -1,6 +1,6 @@
-import AttributeInputCallback from './attribute-input-callback';
 import { CallbackType } from '../../auth/enums';
 import { Callback } from '../../auth/interfaces';
+import AttributeInputCallback from './attribute-input-callback';
 
 describe('AttributeInputCallback', () => {
   const payload: Callback = {
@@ -44,8 +44,8 @@ describe('AttributeInputCallback', () => {
     expect(cb.getName()).toBe('givenName');
     expect(cb.getPrompt()).toBe('First Name:');
     expect(cb.isRequired()).toBe(true);
-    expect(cb.getPolicyKeys()).toStrictEqual(['a', 'b']);
-    expect(cb.getFailedPolicyKeys()).toStrictEqual(['c', 'd']);
+    expect(cb.getPolicies()).toStrictEqual(['a', 'b']);
+    expect(cb.getFailedPolicies()).toStrictEqual(['c', 'd']);
     expect(cb.getInputValue()).toBe('Clark');
   });
 });

--- a/src/fr-auth/callbacks/attribute-input-callback.ts
+++ b/src/fr-auth/callbacks/attribute-input-callback.ts
@@ -1,5 +1,5 @@
 import FRCallback from '.';
-import { Callback } from '../../auth/interfaces';
+import { Callback, PolicyRequirement } from '../../auth/interfaces';
 
 /**
  * Represents a callback used to collect attributes.
@@ -36,17 +36,17 @@ class AttributeInputCallback<T extends string | boolean> extends FRCallback {
   }
 
   /**
-   * Gets the attribute policy keys.
+   * Gets the callback's failed policies.
    */
-  public getPolicyKeys(): string[] {
-    return this.getOutputValue('policies');
+  public getFailedPolicies(): PolicyRequirement[] {
+    return this.getOutputByName<PolicyRequirement[]>('failedPolicies', []);
   }
 
   /**
-   * Gets the attribute policy keys that are not satisfied.
+   * Gets the callback's applicable policies.
    */
-  public getFailedPolicyKeys(): string[] {
-    return this.getOutputValue('failedPolicies');
+  public getPolicies(): string[] {
+    return this.getOutputValue('policies');
   }
 
   /**

--- a/src/fr-auth/callbacks/attribute-input-callback.ts
+++ b/src/fr-auth/callbacks/attribute-input-callback.ts
@@ -18,21 +18,21 @@ class AttributeInputCallback<T extends string | boolean> extends FRCallback {
    * Gets the attribute name.
    */
   public getName(): string {
-    return this.getOutputValue('name');
+    return this.getOutputByName<string>('name', '');
   }
 
   /**
    * Gets the attribute prompt.
    */
   public getPrompt(): string {
-    return this.getOutputValue('prompt');
+    return this.getOutputByName<string>('prompt', '');
   }
 
   /**
    * Gets whether the attribute is required.
    */
   public isRequired(): boolean {
-    return this.getOutputValue('required');
+    return this.getOutputByName<boolean>('required', false);
   }
 
   /**
@@ -46,13 +46,13 @@ class AttributeInputCallback<T extends string | boolean> extends FRCallback {
    * Gets the callback's applicable policies.
    */
   public getPolicies(): string[] {
-    return this.getOutputValue('policies');
+    return this.getOutputByName<string[]>('policies', []);
   }
 
   /**
    * Sets the attribute's value.
    */
-  public setValue(value: T) {
+  public setValue(value: T): void {
     this.setInputValue(value);
   }
 }

--- a/src/fr-auth/callbacks/choice-callback.ts
+++ b/src/fr-auth/callbacks/choice-callback.ts
@@ -16,27 +16,27 @@ class ChoiceCallback extends FRCallback {
    * Gets the choice's prompt.
    */
   public getPrompt(): string {
-    return this.getOutputValue('prompt');
+    return this.getOutputByName<string>('prompt', '');
   }
 
   /**
    * Gets the choice's default answer.
    */
   public getDefaultChoice(): number {
-    return this.getOutputValue('defaultChoice');
+    return this.getOutputByName<number>('defaultChoice', 0);
   }
 
   /**
    * Gets the choice's possible answers.
    */
   public getChoices(): string[] {
-    return this.getOutputValue('choices');
+    return this.getOutputByName<string[]>('choices', []);
   }
 
   /**
    * Sets the choice's answer by index position.
    */
-  public setChoiceIndex(index: number) {
+  public setChoiceIndex(index: number): void {
     const length = this.getChoices().length;
     if (index < 0 || index > length - 1) {
       throw new Error(`${index} is out of bounds`);
@@ -47,7 +47,7 @@ class ChoiceCallback extends FRCallback {
   /**
    * Sets the choice's answer by value.
    */
-  public setChoiceValue(value: string) {
+  public setChoiceValue(value: string): void {
     const index = this.getChoices().indexOf(value);
     if (index === -1) {
       throw new Error(`"${value}" is not a valid choice`);

--- a/src/fr-auth/callbacks/confirmation-callback.ts
+++ b/src/fr-auth/callbacks/confirmation-callback.ts
@@ -16,35 +16,35 @@ class ConfirmationCallback extends FRCallback {
    * Gets the index position of the confirmation's default answer.
    */
   public getDefaultOption(): number {
-    return Number(this.getOutputValue('defaultOption'));
+    return Number(this.getOutputByName<number>('defaultOption', 0));
   }
 
   /**
    * Gets the confirmation's message type.
    */
   public getMessageType(): number {
-    return Number(this.getOutputValue('messageType'));
+    return Number(this.getOutputByName<number>('messageType', 0));
   }
 
   /**
    * Gets the confirmation's possible answers.
    */
   public getOptions(): string[] {
-    return this.getOutputValue('options');
+    return this.getOutputByName<string[]>('options', []);
   }
 
   /**
    * Gets the confirmation's option type.
    */
   public getOptionType(): number {
-    return Number(this.getOutputValue('optionType'));
+    return Number(this.getOutputByName<number>('optionType', 0));
   }
 
   /**
    * Gets the confirmation's prompt.
    */
   public getPrompt(): string {
-    return this.getOutputValue('prompt');
+    return this.getOutputByName<string>('prompt', '');
   }
 }
 

--- a/src/fr-auth/callbacks/factory.ts
+++ b/src/fr-auth/callbacks/factory.ts
@@ -21,7 +21,7 @@ type FRCallbackFactory = (callback: Callback) => FRCallback;
 /**
  * @hidden
  */
-function createCallback(callback: Callback) {
+function createCallback(callback: Callback): FRCallback {
   switch (callback.type) {
     case CallbackType.BooleanAttributeInputCallback:
       return new AttributeInputCallback<boolean>(callback);

--- a/src/fr-auth/callbacks/index.ts
+++ b/src/fr-auth/callbacks/index.ts
@@ -47,17 +47,13 @@ class FRCallback {
   }
 
   /**
-   * Gets the first output element with the specified name.
+   * Gets the value of the first output element with the specified name or the specified default value.
    *
-   * @deprecated Use `getOutputValue(name)` instead
    * @param name The name of the desired element
    */
-  public getOutputByName(name: string): NameValue {
-    const entry = this.payload.output.find((x) => x.name === name);
-    if (!entry) {
-      throw new Error(`Missing callback output entry "${name}"`);
-    }
-    return entry;
+  public getOutputByName<T>(name: string, defaultValue: T): T {
+    const output = this.payload.output.find((x) => x.name === name);
+    return output ? output.value : defaultValue;
   }
 
   private getArrayElement(array: NameValue[], selector: number | string = 0) {

--- a/src/fr-auth/callbacks/index.ts
+++ b/src/fr-auth/callbacks/index.ts
@@ -22,7 +22,7 @@ class FRCallback {
    *
    * @param selector The index position or name of the desired element
    */
-  public getInputValue(selector: number | string = 0) {
+  public getInputValue(selector: number | string = 0): unknown {
     return this.getArrayElement(this.payload.input, selector).value;
   }
 
@@ -32,31 +32,32 @@ class FRCallback {
    *
    * @param selector The index position or name of the desired element
    */
-  public setInputValue(value: any, selector: number | string = 0) {
+  public setInputValue(value: unknown, selector: number | string = 0): void {
     this.getArrayElement(this.payload.input, selector).value = value;
   }
 
   /**
-   * Gets the value of the specified output element, or the first element if `selector` is not
-   * provided.
+   * Gets the value of the specified output element, or the first element if `selector`
+   * is not provided.
    *
    * @param selector The index position or name of the desired element
    */
-  public getOutputValue(selector: number | string = 0) {
+  public getOutputValue(selector: number | string = 0): unknown {
     return this.getArrayElement(this.payload.output, selector).value;
   }
 
   /**
-   * Gets the value of the first output element with the specified name or the specified default value.
+   * Gets the value of the first output element with the specified name or the
+   * specified default value.
    *
    * @param name The name of the desired element
    */
   public getOutputByName<T>(name: string, defaultValue: T): T {
     const output = this.payload.output.find((x) => x.name === name);
-    return output ? output.value : defaultValue;
+    return output ? (output.value as T) : defaultValue;
   }
 
-  private getArrayElement(array: NameValue[], selector: number | string = 0) {
+  private getArrayElement(array: NameValue[], selector: number | string = 0): NameValue {
     if (typeof selector === 'number') {
       if (selector < 0 || selector > array.length - 1) {
         throw new Error(`Selector index ${selector} is out of range`);

--- a/src/fr-auth/callbacks/kba-create-callback.ts
+++ b/src/fr-auth/callbacks/kba-create-callback.ts
@@ -16,31 +16,31 @@ class KbaCreateCallback extends FRCallback {
    * Gets the callback prompt.
    */
   public getPrompt(): string {
-    return this.getOutputValue('prompt');
+    return this.getOutputByName<string>('prompt', '');
   }
 
   /**
    * Gets the callback's list of pre-defined security questions.
    */
   public getPredefinedQuestions(): string[] {
-    return this.getOutputValue('predefinedQuestions');
+    return this.getOutputByName<string[]>('predefinedQuestions', []);
   }
 
   /**
    * Sets the callback's security question.
    */
-  public setQuestion(question: string) {
+  public setQuestion(question: string): void {
     this.setValue('question', question);
   }
 
   /**
    * Sets the callback's security question answer.
    */
-  public setAnswer(answer: string) {
+  public setAnswer(answer: string): void {
     this.setValue('answer', answer);
   }
 
-  private setValue(type: 'question' | 'answer', value: string) {
+  private setValue(type: 'question' | 'answer', value: string): void {
     const input = this.payload.input.find((x) => x.name.endsWith(type));
     if (!input) {
       throw new Error(`No input has name ending in "${type}"`);

--- a/src/fr-auth/callbacks/metadata-callback.ts
+++ b/src/fr-auth/callbacks/metadata-callback.ts
@@ -16,7 +16,7 @@ class MetadataCallback extends FRCallback {
    * Gets the callback's data.
    */
   public getData<T>(): T {
-    return this.getOutputValue('data');
+    return this.getOutputByName<T>('data', {} as T);
   }
 }
 

--- a/src/fr-auth/callbacks/name-callback.ts
+++ b/src/fr-auth/callbacks/name-callback.ts
@@ -16,13 +16,13 @@ class NameCallback extends FRCallback {
    * Gets the callback's prompt.
    */
   public getPrompt(): string {
-    return this.getOutputValue('prompt');
+    return this.getOutputByName<string>('prompt', '');
   }
 
   /**
    * Sets the username.
    */
-  public setName(name: string) {
+  public setName(name: string): void {
     this.setInputValue(name);
   }
 }

--- a/src/fr-auth/callbacks/password-callback.ts
+++ b/src/fr-auth/callbacks/password-callback.ts
@@ -1,5 +1,5 @@
 import FRCallback from '.';
-import { Callback } from '../../auth/interfaces';
+import { Callback, PolicyRequirement } from '../../auth/interfaces';
 
 /**
  * Represents a callback used to collect a password.
@@ -10,6 +10,20 @@ class PasswordCallback extends FRCallback {
    */
   constructor(public payload: Callback) {
     super(payload);
+  }
+
+  /**
+   * Gets the callback's failed policies.
+   */
+  public getFailedPolicies(): PolicyRequirement[] {
+    return this.getOutputByName<PolicyRequirement[]>('failedPolicies', []);
+  }
+
+  /**
+   * Gets the callback's applicable policies.
+   */
+  public getPolicies(): string[] {
+    return this.getOutputValue('policies');
   }
 
   /**

--- a/src/fr-auth/callbacks/password-callback.ts
+++ b/src/fr-auth/callbacks/password-callback.ts
@@ -23,20 +23,20 @@ class PasswordCallback extends FRCallback {
    * Gets the callback's applicable policies.
    */
   public getPolicies(): string[] {
-    return this.getOutputValue('policies');
+    return this.getOutputByName<string[]>('policies', []);
   }
 
   /**
    * Gets the callback's prompt.
    */
   public getPrompt(): string {
-    return this.getOutputValue('prompt');
+    return this.getOutputByName<string>('prompt', '');
   }
 
   /**
    * Sets the password.
    */
-  public setPassword(password: string) {
+  public setPassword(password: string): void {
     this.setInputValue(password);
   }
 }

--- a/src/fr-auth/callbacks/polling-wait-callback.ts
+++ b/src/fr-auth/callbacks/polling-wait-callback.ts
@@ -16,14 +16,14 @@ class PollingWaitCallback extends FRCallback {
    * Gets the message to display while polling.
    */
   public getMessage(): string {
-    return this.getOutputValue('message');
+    return this.getOutputByName<string>('message', '');
   }
 
   /**
    * Gets the polling interval in seconds.
    */
   public getWaitTime(): number {
-    return Number(this.getOutputValue('waitTime'));
+    return Number(this.getOutputByName<number>('waitTime', 0));
   }
 }
 

--- a/src/fr-auth/callbacks/recaptcha-callback.ts
+++ b/src/fr-auth/callbacks/recaptcha-callback.ts
@@ -16,13 +16,13 @@ class ReCaptchaCallback extends FRCallback {
    * Gets the reCAPTCHA site key.
    */
   public getSiteKey(): string {
-    return this.getOutputValue('recaptchaSiteKey');
+    return this.getOutputByName<string>('recaptchaSiteKey', '');
   }
 
   /**
    * Sets the reCAPTCHA result.
    */
-  public setResult(result: string) {
+  public setResult(result: string): void {
     this.setInputValue(result);
   }
 }

--- a/src/fr-auth/callbacks/terms-and-conditions-callback.ts
+++ b/src/fr-auth/callbacks/terms-and-conditions-callback.ts
@@ -16,27 +16,28 @@ class TermsAndConditionsCallback extends FRCallback {
    * Gets the terms and conditions content.
    */
   public getTerms(): string {
-    return this.getOutputValue('terms');
+    return this.getOutputByName<string>('terms', '');
   }
 
   /**
    * Gets the version of the terms and conditions.
    */
   public getVersion(): string {
-    return this.getOutputValue('version');
+    return this.getOutputByName<string>('version', '');
   }
 
   /**
    * Gets the date of the terms and conditions.
    */
   public getCreateDate(): Date {
-    return new Date(this.getOutputValue('createDate'));
+    const date = this.getOutputByName<string>('createDate', '');
+    return new Date(date);
   }
 
   /**
    * Sets the callback's acceptance.
    */
-  public setAccepted(accepted = true) {
+  public setAccepted(accepted = true): void {
     this.setInputValue(accepted);
   }
 }

--- a/src/fr-auth/callbacks/terms-and-conditions-callback.ts
+++ b/src/fr-auth/callbacks/terms-and-conditions-callback.ts
@@ -34,10 +34,10 @@ class TermsAndConditionsCallback extends FRCallback {
   }
 
   /**
-   * Sets the callback's acceptance to `true`.
+   * Sets the callback's acceptance.
    */
-  public setAccepted() {
-    this.setInputValue(true);
+  public setAccepted(accepted = true) {
+    this.setInputValue(accepted);
   }
 }
 

--- a/src/fr-auth/callbacks/text-output-callback.ts
+++ b/src/fr-auth/callbacks/text-output-callback.ts
@@ -16,14 +16,14 @@ class TextOutputCallback extends FRCallback {
    * Gets the message content.
    */
   public getMessage(): string {
-    return this.getOutputValue('message');
+    return this.getOutputByName<string>('message', '');
   }
 
   /**
    * Gets the message type.
    */
   public getMessageType(): string {
-    return this.getOutputValue('messageType');
+    return this.getOutputByName<string>('messageType', '');
   }
 }
 

--- a/src/fr-auth/callbacks/validated-create-password-callback.ts
+++ b/src/fr-auth/callbacks/validated-create-password-callback.ts
@@ -23,41 +23,27 @@ class ValidatedCreatePasswordCallback extends FRCallback {
    * Gets the callback's applicable policies.
    */
   public getPolicies(): string[] {
-    return this.getOutputValue('policies');
+    return this.getOutputByName<string[]>('policies', []);
   }
 
   /**
    * Gets the callback's prompt.
    */
   public getPrompt(): string {
-    return this.getOutputValue('prompt');
+    return this.getOutputByName<string>('prompt', '');
   }
 
   /**
    * Gets whether the password is required.
    */
   public isRequired(): boolean {
-    return this.getOutputValue('required');
-  }
-
-  /**
-   * Gets the password policy keys.
-   */
-  public getPolicyKeys(): string[] {
-    return this.getOutputValue('policies');
-  }
-
-  /**
-   * Gets the password policy keys that are not satisfied.
-   */
-  public getFailedPolicyKeys(): string[] {
-    return this.getOutputValue('failedPolicies');
+    return this.getOutputByName<boolean>('required', false);
   }
 
   /**
    * Sets the callback's password.
    */
-  public setPassword(password: string) {
+  public setPassword(password: string): void {
     this.setInputValue(password);
   }
 }

--- a/src/fr-auth/callbacks/validated-create-password-callback.ts
+++ b/src/fr-auth/callbacks/validated-create-password-callback.ts
@@ -1,5 +1,5 @@
 import FRCallback from '.';
-import { Callback } from '../../auth/interfaces';
+import { Callback, PolicyRequirement } from '../../auth/interfaces';
 
 /**
  * Represents a callback used to collect a valid platform password.
@@ -10,6 +10,20 @@ class ValidatedCreatePasswordCallback extends FRCallback {
    */
   constructor(public payload: Callback) {
     super(payload);
+  }
+
+  /**
+   * Gets the callback's failed policies.
+   */
+  public getFailedPolicies(): PolicyRequirement[] {
+    return this.getOutputByName<PolicyRequirement[]>('failedPolicies', []);
+  }
+
+  /**
+   * Gets the callback's applicable policies.
+   */
+  public getPolicies(): string[] {
+    return this.getOutputValue('policies');
   }
 
   /**

--- a/src/fr-auth/callbacks/validated-create-username-callback.ts
+++ b/src/fr-auth/callbacks/validated-create-username-callback.ts
@@ -1,5 +1,5 @@
 import FRCallback from '.';
-import { Callback } from '../../auth/interfaces';
+import { Callback, PolicyRequirement } from '../../auth/interfaces';
 
 /**
  * Represents a callback used to collect a valid platform username.
@@ -27,17 +27,17 @@ class ValidatedCreateUsernameCallback extends FRCallback {
   }
 
   /**
-   * Gets the username policy keys.
+   * Gets the callback's failed policies.
    */
-  public getPolicyKeys(): string[] {
-    return this.getOutputValue('policies');
+  public getFailedPolicies(): PolicyRequirement[] {
+    return this.getOutputByName<PolicyRequirement[]>('failedPolicies', []);
   }
 
   /**
-   * Gets the username policy keys that are not satisfied.
+   * Gets the callback's applicable policies.
    */
-  public getFailedPolicyKeys(): string[] {
-    return this.getOutputValue('failedPolicies');
+  public getPolicies(): string[] {
+    return this.getOutputValue('policies');
   }
 
   /**

--- a/src/fr-auth/callbacks/validated-create-username-callback.ts
+++ b/src/fr-auth/callbacks/validated-create-username-callback.ts
@@ -16,14 +16,7 @@ class ValidatedCreateUsernameCallback extends FRCallback {
    * Gets the callback's prompt.
    */
   public getPrompt(): string {
-    return this.getOutputValue('prompt');
-  }
-
-  /**
-   * Gets whether the username is required.
-   */
-  public isRequired(): boolean {
-    return this.getOutputValue('required');
+    return this.getOutputByName<string>('prompt', '');
   }
 
   /**
@@ -37,13 +30,20 @@ class ValidatedCreateUsernameCallback extends FRCallback {
    * Gets the callback's applicable policies.
    */
   public getPolicies(): string[] {
-    return this.getOutputValue('policies');
+    return this.getOutputByName<string[]>('policies', []);
+  }
+
+  /**
+   * Gets whether the username is required.
+   */
+  public isRequired(): boolean {
+    return this.getOutputByName<boolean>('required', false);
   }
 
   /**
    * Sets the callback's username.
    */
-  public setName(name: string) {
+  public setName(name: string): void {
     this.setInputValue(name);
   }
 }

--- a/src/fr-auth/fr-login-success.ts
+++ b/src/fr-auth/fr-login-success.ts
@@ -16,21 +16,21 @@ class FRLoginSuccess implements AuthResponse {
   /**
    * Gets the step's realm.
    */
-  public getRealm() {
+  public getRealm(): string | undefined {
     return this.payload.realm;
   }
 
   /**
    * Gets the step's session token.
    */
-  public getSessionToken() {
+  public getSessionToken(): string | undefined {
     return this.payload.tokenId;
   }
 
   /**
    * Gets the step's success URL.
    */
-  public getSuccessUrl() {
+  public getSuccessUrl(): string | undefined {
     return this.payload.successUrl;
   }
 }

--- a/src/fr-auth/fr-step.ts
+++ b/src/fr-auth/fr-step.ts
@@ -57,7 +57,7 @@ class FRStep implements AuthResponse {
    * @param type The type of callback to find.
    * @param value The value to set for the callback.
    */
-  public setCallbackValue(type: CallbackType, value: any) {
+  public setCallbackValue(type: CallbackType, value: unknown): void {
     const callbacks = this.getCallbacksOfType(type);
     if (callbacks.length !== 1) {
       throw new Error(`Expected 1 callback of type "${type}", but found ${callbacks.length}`);
@@ -68,25 +68,28 @@ class FRStep implements AuthResponse {
   /**
    * Gets the step's description.
    */
-  public getDescription() {
+  public getDescription(): string | undefined {
     return this.payload.description;
   }
 
   /**
    * Gets the step's header.
    */
-  public getHeader() {
+  public getHeader(): string | undefined {
     return this.payload.header;
   }
 
   /**
    * Gets the step's stage.
    */
-  public getStage() {
+  public getStage(): string | undefined {
     return this.payload.stage;
   }
 
-  private convertCallbacks(callbacks: Callback[], callbackFactory?: FRCallbackFactory) {
+  private convertCallbacks(
+    callbacks: Callback[],
+    callbackFactory?: FRCallbackFactory,
+  ): FRCallback[] {
     const converted = callbacks.map((x: Callback) => {
       // This gives preference to the provided factory and falls back to our default implementation
       return (callbackFactory || createCallback)(x) || createCallback(x);

--- a/src/fr-auth/index.ts
+++ b/src/fr-auth/index.ts
@@ -1,5 +1,5 @@
-import { ConfigOptions } from 'config';
 import Auth from '../auth/index';
+import { ConfigOptions } from '../config';
 import FRLoginFailure from './fr-login-failure';
 import FRLoginSuccess from './fr-login-success';
 import FRStep from './fr-step';

--- a/src/fr-policy/enums.ts
+++ b/src/fr-policy/enums.ts
@@ -1,7 +1,3 @@
-import { PolicyParams } from '../auth/interfaces';
-import { plural } from '../util/strings';
-import { MessageCreator } from './interfaces';
-
 enum PolicyKey {
   CannotContainCharacters = 'CANNOT_CONTAIN_CHARACTERS',
   CannotContainDuplicates = 'CANNOT_CONTAIN_DUPLICATES',
@@ -26,63 +22,4 @@ enum PolicyKey {
   ValidType = 'VALID_TYPE',
 }
 
-const policyMessage: MessageCreator = {
-  [PolicyKey.CannotContainCharacters]: (
-    property: string,
-    params: Pick<PolicyParams, 'forbiddenChars'>,
-  ) => {
-    const forbiddenChars: string = params.forbiddenChars;
-    return `${property} must not contain following characters: "${forbiddenChars}"`;
-  },
-  [PolicyKey.CannotContainDuplicates]: (
-    property: string,
-    params: Pick<PolicyParams, 'duplicateValue'>,
-  ) => {
-    const duplicateValue: string = params.duplicateValue;
-    return `${property}  must not contain duplicates: "${duplicateValue}"`;
-  },
-  [PolicyKey.CannotContainOthers]: (
-    property: string,
-    params: Pick<PolicyParams, 'disallowedFields'>,
-  ) => {
-    const disallowedFields: string = params.disallowedFields;
-    return `${property} must not contain: "${disallowedFields}"`;
-  },
-  [PolicyKey.LeastCapitalLetters]: (property: string, params: Pick<PolicyParams, 'numCaps'>) => {
-    const numCaps: number = params.numCaps;
-    return `${property} must contain at least ${numCaps} capital ${plural(numCaps, 'letter')}`;
-  },
-  [PolicyKey.LeastNumbers]: (property: string, params: Pick<PolicyParams, 'numNums'>) => {
-    const numNums: number = params.numNums;
-    return `${property} must contain at least ${numNums} numeric ${plural(numNums, 'value')}`;
-  },
-  [PolicyKey.MatchRegexp]: (property: string) => `${property} has failed the "MATCH_REGEXP" policy`,
-  [PolicyKey.MaximumLength]: (property: string, params: Pick<PolicyParams, 'maxLength'>) => {
-    const maxLength: number = params.maxLength;
-    return `${property} must be at most ${maxLength} ${plural(maxLength, 'character')}`;
-  },
-  [PolicyKey.MaximumNumber]: (property: string) =>
-    `${property} has failed the "MAXIMUM_NUMBER_VALUE" policy`,
-  [PolicyKey.MinimumLength]: (property: string, params: Pick<PolicyParams, 'minLength'>) => {
-    const minLength: number = params.minLength;
-    return `${property} must be at least ${minLength} ${plural(minLength, 'character')}`;
-  },
-  [PolicyKey.MinimumNumber]: (property: string) =>
-    `${property} has failed the "MINIMUM_NUMBER_VALUE" policy`,
-  [PolicyKey.Required]: (property: string) => `${property} is required`,
-  [PolicyKey.Unique]: (property: string) => `${property} must be unique`,
-  [PolicyKey.UnknownPolicy]: (property: string, params: { policyRequirement: string }) =>
-    `${property}: Unknown policy requirement "${params.policyRequirement}"`,
-  [PolicyKey.ValidArrayItems]: (property: string) =>
-    `${property} has failed the "VALID_ARRAY_ITEMS" policy`,
-  [PolicyKey.ValidDate]: (property: string) => `${property} has an invalid date`,
-  [PolicyKey.ValidEmailAddress]: (property: string) => `${property} has an invalid email address`,
-  [PolicyKey.ValidNameFormat]: (property: string) => `${property} has an invalid name format`,
-  [PolicyKey.ValidNumber]: (property: string) => `${property} has an invalid number`,
-  [PolicyKey.ValidPhoneFormat]: (property: string) => `${property} has an invalid phone number`,
-  [PolicyKey.ValidQueryFilter]: (property: string) =>
-    `${property} has failed the "VALID_QUERY_FILTER" policy`,
-  [PolicyKey.ValidType]: (property: string) => `${property} has failed the "VALID_TYPE" policy`,
-};
-
-export { PolicyKey, policyMessage };
+export { PolicyKey };

--- a/src/fr-policy/fr-policy.test.ts
+++ b/src/fr-policy/fr-policy.test.ts
@@ -46,7 +46,7 @@ describe('The IDM error handling', () => {
   it('error handling is extensible by customer', () => {
     const test = {
       customMessage: {
-        CUSTOM_POLICY: (property: string, params: any) =>
+        CUSTOM_POLICY: (property: string, params: { policyRequirement: string }): string =>
           `this is a custom message for "${params.policyRequirement}" policy of ${property}`,
       },
       expectedString: `this is a custom message for "CUSTOM_POLICY" policy of ${property}`,
@@ -61,7 +61,7 @@ describe('The IDM error handling', () => {
   it('error handling is overwritable by customer', () => {
     const test = {
       customMessage: {
-        [PolicyKey.Unique]: (property: string) =>
+        [PolicyKey.Unique]: (property: string): string =>
           `this is a custom message for "UNIQUE" policy of ${property}`,
       },
       expectedString: `this is a custom message for "UNIQUE" policy of ${property}`,
@@ -142,9 +142,9 @@ describe('The IDM error handling', () => {
       },
     };
     const customMessage = {
-      [PolicyKey.Unique]: (property: string) =>
+      [PolicyKey.Unique]: (property: string): string =>
         `this is a custom message for "UNIQUE" policy of ${property}`,
-      CUSTOM_POLICY: (property: string, params: any) =>
+      CUSTOM_POLICY: (property: string, params: { policyRequirement: string }): string =>
         `this is a custom message for "${params.policyRequirement}" policy of ${property}`,
     };
     const expected = [

--- a/src/fr-policy/helpers.ts
+++ b/src/fr-policy/helpers.ts
@@ -1,0 +1,8 @@
+function getProp<T>(obj: { [key: string]: unknown } | undefined, prop: string, defaultValue: T): T {
+  if (!obj || obj[prop] === undefined) {
+    return defaultValue;
+  }
+  return obj[prop] as T;
+}
+
+export { getProp };

--- a/src/fr-policy/interfaces.ts
+++ b/src/fr-policy/interfaces.ts
@@ -1,7 +1,7 @@
 import { FailedPolicyRequirement } from '../auth/interfaces';
 
 interface MessageCreator {
-  [key: string]: (propertyName: string, params?: any) => string;
+  [key: string]: (propertyName: string, params?: { [key: string]: unknown }) => string;
 }
 
 interface ProcessedPropertyError {

--- a/src/fr-policy/message-creator.ts
+++ b/src/fr-policy/message-creator.ts
@@ -1,5 +1,6 @@
 import { plural } from '../util/strings';
 import { PolicyKey } from './enums';
+import { getProp } from './helpers';
 import { MessageCreator } from './interfaces';
 
 const defaultMessageCreator: MessageCreator = {
@@ -53,12 +54,5 @@ const defaultMessageCreator: MessageCreator = {
     `${property} has failed the "VALID_QUERY_FILTER" policy`,
   [PolicyKey.ValidType]: (property: string) => `${property} has failed the "VALID_TYPE" policy`,
 };
-
-function getProp<T>(obj: { [key: string]: unknown } | undefined, prop: string, defaultValue: T): T {
-  if (!obj || obj[prop] === undefined) {
-    return defaultValue;
-  }
-  return obj[prop] as T;
-}
 
 export default defaultMessageCreator;

--- a/src/fr-policy/message-creator.ts
+++ b/src/fr-policy/message-creator.ts
@@ -1,0 +1,65 @@
+import { PolicyParams } from '../auth/interfaces';
+import { plural } from '../util/strings';
+import { PolicyKey } from './enums';
+import { MessageCreator } from './interfaces';
+
+const defaultMessageCreator: MessageCreator = {
+  [PolicyKey.CannotContainCharacters]: (
+    property: string,
+    params: Pick<PolicyParams, 'forbiddenChars'>,
+  ) => {
+    const forbiddenChars: string = params.forbiddenChars;
+    return `${property} must not contain following characters: "${forbiddenChars}"`;
+  },
+  [PolicyKey.CannotContainDuplicates]: (
+    property: string,
+    params: Pick<PolicyParams, 'duplicateValue'>,
+  ) => {
+    const duplicateValue: string = params.duplicateValue;
+    return `${property}  must not contain duplicates: "${duplicateValue}"`;
+  },
+  [PolicyKey.CannotContainOthers]: (
+    property: string,
+    params: Pick<PolicyParams, 'disallowedFields'>,
+  ) => {
+    const disallowedFields: string = params.disallowedFields;
+    return `${property} must not contain: "${disallowedFields}"`;
+  },
+  [PolicyKey.LeastCapitalLetters]: (property: string, params: Pick<PolicyParams, 'numCaps'>) => {
+    const numCaps: number = params.numCaps;
+    return `${property} must contain at least ${numCaps} capital ${plural(numCaps, 'letter')}`;
+  },
+  [PolicyKey.LeastNumbers]: (property: string, params: Pick<PolicyParams, 'numNums'>) => {
+    const numNums: number = params.numNums;
+    return `${property} must contain at least ${numNums} numeric ${plural(numNums, 'value')}`;
+  },
+  [PolicyKey.MatchRegexp]: (property: string) => `${property} has failed the "MATCH_REGEXP" policy`,
+  [PolicyKey.MaximumLength]: (property: string, params: Pick<PolicyParams, 'maxLength'>) => {
+    const maxLength: number = params.maxLength;
+    return `${property} must be at most ${maxLength} ${plural(maxLength, 'character')}`;
+  },
+  [PolicyKey.MaximumNumber]: (property: string) =>
+    `${property} has failed the "MAXIMUM_NUMBER_VALUE" policy`,
+  [PolicyKey.MinimumLength]: (property: string, params: Pick<PolicyParams, 'minLength'>) => {
+    const minLength: number = params.minLength;
+    return `${property} must be at least ${minLength} ${plural(minLength, 'character')}`;
+  },
+  [PolicyKey.MinimumNumber]: (property: string) =>
+    `${property} has failed the "MINIMUM_NUMBER_VALUE" policy`,
+  [PolicyKey.Required]: (property: string) => `${property} is required`,
+  [PolicyKey.Unique]: (property: string) => `${property} must be unique`,
+  [PolicyKey.UnknownPolicy]: (property: string, params: { policyRequirement: string }) =>
+    `${property}: Unknown policy requirement "${params.policyRequirement}"`,
+  [PolicyKey.ValidArrayItems]: (property: string) =>
+    `${property} has failed the "VALID_ARRAY_ITEMS" policy`,
+  [PolicyKey.ValidDate]: (property: string) => `${property} has an invalid date`,
+  [PolicyKey.ValidEmailAddress]: (property: string) => `${property} has an invalid email address`,
+  [PolicyKey.ValidNameFormat]: (property: string) => `${property} has an invalid name format`,
+  [PolicyKey.ValidNumber]: (property: string) => `${property} has an invalid number`,
+  [PolicyKey.ValidPhoneFormat]: (property: string) => `${property} has an invalid phone number`,
+  [PolicyKey.ValidQueryFilter]: (property: string) =>
+    `${property} has failed the "VALID_QUERY_FILTER" policy`,
+  [PolicyKey.ValidType]: (property: string) => `${property} has failed the "VALID_TYPE" policy`,
+};
+
+export default defaultMessageCreator;

--- a/src/fr-policy/message-creator.ts
+++ b/src/fr-policy/message-creator.ts
@@ -1,55 +1,47 @@
-import { PolicyParams } from '../auth/interfaces';
 import { plural } from '../util/strings';
 import { PolicyKey } from './enums';
 import { MessageCreator } from './interfaces';
 
 const defaultMessageCreator: MessageCreator = {
-  [PolicyKey.CannotContainCharacters]: (
-    property: string,
-    params: Pick<PolicyParams, 'forbiddenChars'>,
-  ) => {
-    const forbiddenChars: string = params.forbiddenChars;
+  [PolicyKey.CannotContainCharacters]: (property: string, params?: { forbiddenChars?: string }) => {
+    const forbiddenChars = getProp<string>(params, 'forbiddenChars', '');
     return `${property} must not contain following characters: "${forbiddenChars}"`;
   },
-  [PolicyKey.CannotContainDuplicates]: (
-    property: string,
-    params: Pick<PolicyParams, 'duplicateValue'>,
-  ) => {
-    const duplicateValue: string = params.duplicateValue;
+  [PolicyKey.CannotContainDuplicates]: (property: string, params?: { duplicateValue?: string }) => {
+    const duplicateValue = getProp<string>(params, 'duplicateValue', '');
     return `${property}  must not contain duplicates: "${duplicateValue}"`;
   },
-  [PolicyKey.CannotContainOthers]: (
-    property: string,
-    params: Pick<PolicyParams, 'disallowedFields'>,
-  ) => {
-    const disallowedFields: string = params.disallowedFields;
+  [PolicyKey.CannotContainOthers]: (property: string, params?: { disallowedFields?: string }) => {
+    const disallowedFields = getProp<string>(params, 'disallowedFields', '');
     return `${property} must not contain: "${disallowedFields}"`;
   },
-  [PolicyKey.LeastCapitalLetters]: (property: string, params: Pick<PolicyParams, 'numCaps'>) => {
-    const numCaps: number = params.numCaps;
+  [PolicyKey.LeastCapitalLetters]: (property: string, params?: { numCaps?: number }) => {
+    const numCaps = getProp<number>(params, 'numCaps', 0);
     return `${property} must contain at least ${numCaps} capital ${plural(numCaps, 'letter')}`;
   },
-  [PolicyKey.LeastNumbers]: (property: string, params: Pick<PolicyParams, 'numNums'>) => {
-    const numNums: number = params.numNums;
+  [PolicyKey.LeastNumbers]: (property: string, params?: { numNums?: number }) => {
+    const numNums = getProp<number>(params, 'numNums', 0);
     return `${property} must contain at least ${numNums} numeric ${plural(numNums, 'value')}`;
   },
   [PolicyKey.MatchRegexp]: (property: string) => `${property} has failed the "MATCH_REGEXP" policy`,
-  [PolicyKey.MaximumLength]: (property: string, params: Pick<PolicyParams, 'maxLength'>) => {
-    const maxLength: number = params.maxLength;
+  [PolicyKey.MaximumLength]: (property: string, params?: { maxLength?: number }) => {
+    const maxLength = getProp<number>(params, 'maxLength', 0);
     return `${property} must be at most ${maxLength} ${plural(maxLength, 'character')}`;
   },
   [PolicyKey.MaximumNumber]: (property: string) =>
     `${property} has failed the "MAXIMUM_NUMBER_VALUE" policy`,
-  [PolicyKey.MinimumLength]: (property: string, params: Pick<PolicyParams, 'minLength'>) => {
-    const minLength: number = params.minLength;
+  [PolicyKey.MinimumLength]: (property: string, params?: { minLength?: number }) => {
+    const minLength = getProp<number>(params, 'minLength', 0);
     return `${property} must be at least ${minLength} ${plural(minLength, 'character')}`;
   },
   [PolicyKey.MinimumNumber]: (property: string) =>
     `${property} has failed the "MINIMUM_NUMBER_VALUE" policy`,
   [PolicyKey.Required]: (property: string) => `${property} is required`,
   [PolicyKey.Unique]: (property: string) => `${property} must be unique`,
-  [PolicyKey.UnknownPolicy]: (property: string, params: { policyRequirement: string }) =>
-    `${property}: Unknown policy requirement "${params.policyRequirement}"`,
+  [PolicyKey.UnknownPolicy]: (property: string, params?: { policyRequirement?: string }) => {
+    const policyRequirement = getProp<string>(params, 'policyRequirement', 'Unknown');
+    return `${property}: Unknown policy requirement "${policyRequirement}"`;
+  },
   [PolicyKey.ValidArrayItems]: (property: string) =>
     `${property} has failed the "VALID_ARRAY_ITEMS" policy`,
   [PolicyKey.ValidDate]: (property: string) => `${property} has an invalid date`,
@@ -61,5 +53,12 @@ const defaultMessageCreator: MessageCreator = {
     `${property} has failed the "VALID_QUERY_FILTER" policy`,
   [PolicyKey.ValidType]: (property: string) => `${property} has failed the "VALID_TYPE" policy`,
 };
+
+function getProp<T>(obj: { [key: string]: unknown } | undefined, prop: string, defaultValue: T): T {
+  if (!obj || obj[prop] === undefined) {
+    return defaultValue;
+  }
+  return obj[prop] as T;
+}
 
 export default defaultMessageCreator;

--- a/src/fr-user/index.ts
+++ b/src/fr-user/index.ts
@@ -48,7 +48,7 @@ abstract class FRUser {
    *
    * @param options Configuration overrides
    */
-  public static async logout(options?: ConfigOptions) {
+  public static async logout(options?: ConfigOptions): Promise<void> {
     try {
       // TODO: Determine if we're using logout() or endSession(). logout() removes
       //       the cookie, but fails with CORS issues currently.

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -34,7 +34,7 @@ abstract class HttpClient extends Dispatcher {
     return await withTimeout(fetch(url, init), timeout);
   }
 
-  private static newTokenRequired(res: Response, requiresNewToken?: RequiresNewTokenFn) {
+  private static newTokenRequired(res: Response, requiresNewToken?: RequiresNewTokenFn): boolean {
     if (typeof requiresNewToken === 'function') {
       return requiresNewToken(res);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import Auth from './auth';
 import { CallbackType, ErrorCode } from './auth/enums';
-import { Callback, NameValue, Step, StepDetail } from './auth/interfaces';
+import { Callback, NameValue, PolicyRequirement, Step, StepDetail } from './auth/interfaces';
 import Config, { ConfigOptions, ValidConfigOptions } from './config';
 import Dispatcher, { CallbackContainer, FREvent, Listener } from './event';
 import FRAuth from './fr-auth';
+import FRCallback from './fr-auth/callbacks';
 import AttributeInputCallback from './fr-auth/callbacks/attribute-input-callback';
 import ChoiceCallback from './fr-auth/callbacks/choice-callback';
 import ConfirmationCallback from './fr-auth/callbacks/confirmation-callback';
@@ -26,6 +27,8 @@ import FRLoginFailure from './fr-auth/fr-login-failure';
 import FRLoginSuccess from './fr-auth/fr-login-success';
 import FRStep, { FRStepHandler } from './fr-auth/fr-step';
 import { AuthResponse, FailureDetail } from './fr-auth/interfaces';
+import FRPolicy, { MessageCreator, PolicyKey, ProcessedPropertyError } from './fr-policy';
+import defaultMessageCreator from './fr-policy/message-creator';
 import FRUI from './fr-ui';
 import FRUser from './fr-user';
 import HttpClient from './http-client';
@@ -44,6 +47,7 @@ import PKCE from './util/pkce';
 import LocalStorage from './util/storage';
 
 export {
+  defaultMessageCreator,
   AttributeInputCallback,
   Auth,
   AuthResponse,
@@ -58,10 +62,12 @@ export {
   ErrorCode,
   FailureDetail,
   FRAuth,
+  FRCallback,
   FRCallbackFactory,
   FREvent,
   FRLoginFailure,
   FRLoginSuccess,
+  FRPolicy,
   FRStep,
   FRStepHandler,
   FRUI,
@@ -74,6 +80,7 @@ export {
   KbaCreateCallback,
   Listener,
   LocalStorage,
+  MessageCreator,
   MetadataCallback,
   NameCallback,
   NameValue,
@@ -81,7 +88,10 @@ export {
   OAuth2Tokens,
   PasswordCallback,
   PKCE,
+  PolicyKey,
+  PolicyRequirement,
   PollingWaitCallback,
+  ProcessedPropertyError,
   ReCaptchaCallback,
   ResponseType,
   SessionManager,

--- a/src/oauth2-client/interfaces.ts
+++ b/src/oauth2-client/interfaces.ts
@@ -11,6 +11,15 @@ interface OAuth2Tokens {
 }
 
 /**
+ * Response from access_token endpoint.
+ */
+interface AccessTokenResponse {
+  access_token: string;
+  id_token: string;
+  refresh_token: string;
+}
+
+/**
  * Options used when requesting the authorization URL.
  */
 interface GetAuthorizationUrlOptions extends ConfigOptions {
@@ -27,4 +36,4 @@ interface GetOAuth2TokensOptions extends ConfigOptions {
   verifier?: string;
 }
 
-export { GetAuthorizationUrlOptions, GetOAuth2TokensOptions, OAuth2Tokens };
+export { AccessTokenResponse, GetAuthorizationUrlOptions, GetOAuth2TokensOptions, OAuth2Tokens };

--- a/src/session-manager/index.ts
+++ b/src/session-manager/index.ts
@@ -11,7 +11,7 @@ abstract class SessionManager {
   /**
    * Ends the current session.
    */
-  public static async logout(options?: ConfigOptions) {
+  public static async logout(options?: ConfigOptions): Promise<void> {
     const { realmPath, serverConfig } = Config.get(options);
     const init: RequestInit = {
       credentials: 'include',

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -1,7 +1,11 @@
+interface AnyObject {
+  [key: string]: {} | null | undefined;
+}
+
 interface Tokens {
   accessToken: string;
   idToken?: string;
   refreshToken?: string;
 }
 
-export { Tokens };
+export { AnyObject, Tokens };

--- a/src/token-manager/index.ts
+++ b/src/token-manager/index.ts
@@ -52,7 +52,7 @@ abstract class TokenManager {
     return tokens;
   }
 
-  public static async deleteTokens() {
+  public static async deleteTokens(): Promise<void> {
     await TokenStorage.remove();
   }
 }

--- a/src/token-storage/interfaces.ts
+++ b/src/token-storage/interfaces.ts
@@ -1,0 +1,11 @@
+import { Tokens } from '../shared/interfaces';
+
+interface TokenDbEventTarget extends EventTarget {
+  result?: Tokens;
+}
+
+interface TokenDbEvent extends Event {
+  target: TokenDbEventTarget | null;
+}
+
+export { TokenDbEvent, TokenDbEventTarget };

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,3 +1,3 @@
 interface Window {
-  PublicKeyCredential: any;
+  PublicKeyCredential: unknown;
 }

--- a/src/user-manager/index.ts
+++ b/src/user-manager/index.ts
@@ -7,7 +7,7 @@ abstract class UserManager {
   /**
    * Gets the current user's profile.
    */
-  public static getCurrentUser() {
+  public static getCurrentUser(): Promise<unknown> {
     return OAuth2Client.getUserInfo();
   }
 }

--- a/src/util/deferred.ts
+++ b/src/util/deferred.ts
@@ -1,7 +1,7 @@
 class Deferred<T> {
   public promise: Promise<T>;
   public resolve!: (value: T) => void;
-  public reject!: (reason: any) => void;
+  public reject!: (reason: unknown) => void;
 
   constructor() {
     this.promise = new Promise<T>((resolve, reject) => {

--- a/src/util/http.ts
+++ b/src/util/http.ts
@@ -1,4 +1,4 @@
-function isOkOr4xx(response: Response) {
+function isOkOr4xx(response: Response): boolean {
   return response.ok || Math.floor(response.status / 100) === 4;
 }
 

--- a/src/util/nonce.ts
+++ b/src/util/nonce.ts
@@ -6,7 +6,7 @@ function nonce(length = 15): () => number {
     throw new Error('Invalid nonce length');
   }
 
-  return () => {
+  return (): number => {
     const now = Math.pow(10, 2) * +new Date();
 
     if (now === last) {

--- a/src/util/pkce.test.ts
+++ b/src/util/pkce.test.ts
@@ -6,13 +6,13 @@ import crypto from 'crypto';
 import { TextEncoder } from 'util';
 import PKCE from './pkce';
 
-declare let window: any;
+declare let window: unknown;
 
 Object.defineProperty(window, 'crypto', {
   value: {
-    getRandomValues: (array: Uint8Array) => crypto.randomBytes(array.length),
+    getRandomValues: (array: Uint8Array): Buffer => crypto.randomBytes(array.length),
     subtle: {
-      digest: (alg: string, array: Uint8Array) => {
+      digest: (alg: string, array: Uint8Array): Buffer => {
         if (alg === 'SHA-256') {
           return crypto
             .createHash('sha256')

--- a/src/util/realm.ts
+++ b/src/util/realm.ts
@@ -1,4 +1,4 @@
-function getRealmUrlPath(realmPath?: string) {
+function getRealmUrlPath(realmPath?: string): string {
   // Split the path and scrub segments
   const names = (realmPath || '')
     .split('/')

--- a/src/util/storage.ts
+++ b/src/util/storage.ts
@@ -13,11 +13,11 @@ class LocalStorage {
     return JSON.parse(value);
   }
 
-  public set<T>(key: string, value: T) {
+  public set<T>(key: string, value: T): void {
     this.storage.setItem(key, JSON.stringify(value));
   }
 
-  public remove(key: string) {
+  public remove(key: string): void {
     this.storage.removeItem(key);
   }
 }

--- a/src/util/strings.ts
+++ b/src/util/strings.ts
@@ -1,4 +1,4 @@
-export function plural(n: number, singularText: string, pluralText?: string) {
+export function plural(n: number, singularText: string, pluralText?: string): string {
   if (n === 1) {
     return singularText;
   }

--- a/src/util/timeout.ts
+++ b/src/util/timeout.ts
@@ -1,10 +1,12 @@
 import { DEFAULT_TIMEOUT } from '../config';
 
-function withTimeout<T>(promise: Promise<T>, timeout: number = DEFAULT_TIMEOUT) {
+function withTimeout<T>(promise: Promise<T>, timeout: number = DEFAULT_TIMEOUT): Promise<T> {
   const effectiveTimeout = timeout || DEFAULT_TIMEOUT;
   return Promise.race([
     promise,
-    new Promise<T>((_, reject) => setTimeout(() => reject(new Error('Timeout')), effectiveTimeout)),
+    new Promise<T>((_, reject) =>
+      window.setTimeout(() => reject(new Error('Timeout')), effectiveTimeout),
+    ),
   ]);
 }
 

--- a/tests/e2e/ambient.d.ts
+++ b/tests/e2e/ambient.d.ts
@@ -1,0 +1,5 @@
+declare const page: {
+  goto: (url: string) => Promise<void>;
+  on: (e: string, fn: (message: unknown) => void) => void;
+  waitForSelector: (e: string, params: unknown) => Promise<void>;
+};

--- a/tests/e2e/bad-login.test.ts
+++ b/tests/e2e/bad-login.test.ts
@@ -1,5 +1,4 @@
 import { AM_URL, BASE_URL, CLIENT_ID, PASSWORD, REALM_PATH, SCOPE, USERNAME } from './config';
-import { page } from './shared';
 
 describe('Test bad login flow', () => {
   beforeAll(async () => {
@@ -23,7 +22,7 @@ describe('Test bad login flow', () => {
     const messageArray = [];
 
     try {
-      page.on('console', (message) => {
+      page.on('console', (message: { _text: string }) => {
         messageArray.push(message._text);
       });
 

--- a/tests/e2e/bad-login.test.ts
+++ b/tests/e2e/bad-login.test.ts
@@ -1,16 +1,14 @@
 import { AM_URL, BASE_URL, CLIENT_ID, PASSWORD, REALM_PATH, SCOPE, USERNAME } from './config';
-
-// Have TS ignore the `page` Puppeteer object
-declare const page: any;
+import { page } from './shared';
 
 describe('Test bad login flow', () => {
   beforeAll(async () => {
     try {
       const url = new URL(BASE_URL);
-      url.searchParams.set('amUrl', AM_URL!);
-      url.searchParams.set('clientId', CLIENT_ID!);
-      url.searchParams.set('realmPath', REALM_PATH!);
-      url.searchParams.set('scope', SCOPE!);
+      url.searchParams.set('amUrl', AM_URL || '');
+      url.searchParams.set('clientId', CLIENT_ID || '');
+      url.searchParams.set('realmPath', REALM_PATH || '');
+      url.searchParams.set('scope', SCOPE || '');
       url.searchParams.set('un', USERNAME);
       url.searchParams.set('pw', `sad_${PASSWORD}_panda`);
 

--- a/tests/e2e/basic-login.test.ts
+++ b/tests/e2e/basic-login.test.ts
@@ -1,18 +1,16 @@
 import { AM_URL, BASE_URL, CLIENT_ID, PASSWORD, REALM_PATH, SCOPE, USERNAME } from './config';
-
-// Have TS ignore the `page` Puppeteer object
-declare const page: any;
+import { page } from './shared';
 
 describe('Test basic login flow', () => {
   beforeAll(async () => {
     try {
       const url = new URL(BASE_URL);
-      url.searchParams.set('amUrl', AM_URL!);
-      url.searchParams.set('clientId', CLIENT_ID!);
-      url.searchParams.set('realmPath', REALM_PATH!);
-      url.searchParams.set('scope', SCOPE!);
-      url.searchParams.set('un', USERNAME!);
-      url.searchParams.set('pw', PASSWORD!);
+      url.searchParams.set('amUrl', AM_URL || '');
+      url.searchParams.set('clientId', CLIENT_ID || '');
+      url.searchParams.set('realmPath', REALM_PATH || '');
+      url.searchParams.set('scope', SCOPE || '');
+      url.searchParams.set('un', USERNAME || '');
+      url.searchParams.set('pw', PASSWORD || '');
 
       // Open browser to test page
       await page.goto(url.toString());
@@ -25,7 +23,7 @@ describe('Test basic login flow', () => {
     const messageArray = [];
 
     try {
-      page.on('console', (message) => {
+      page.on('console', (message: { _text: string }) => {
         messageArray.push(message._text);
       });
 

--- a/tests/e2e/basic-login.test.ts
+++ b/tests/e2e/basic-login.test.ts
@@ -1,5 +1,4 @@
 import { AM_URL, BASE_URL, CLIENT_ID, PASSWORD, REALM_PATH, SCOPE, USERNAME } from './config';
-import { page } from './shared';
 
 describe('Test basic login flow', () => {
   beforeAll(async () => {

--- a/tests/e2e/shared.ts
+++ b/tests/e2e/shared.ts
@@ -1,7 +1,7 @@
 const page = {
-  goto: (url: string) => Promise.resolve(),
-  on: (e: string, params: unknown) => Promise.resolve(),
-  waitForSelector: (selector: string, params: unknown) => Promise.resolve(),
+  goto: (): Promise<void> => Promise.resolve(),
+  on: (): Promise<void> => Promise.resolve(),
+  waitForSelector: (): Promise<void> => Promise.resolve(),
 };
 
 export { page };

--- a/tests/e2e/shared.ts
+++ b/tests/e2e/shared.ts
@@ -1,0 +1,7 @@
+const page = {
+  goto: (url: string) => Promise.resolve(),
+  on: (e: string, params: unknown) => Promise.resolve(),
+  waitForSelector: (selector: string, params: unknown) => Promise.resolve(),
+};
+
+export { page };

--- a/tests/e2e/shared.ts
+++ b/tests/e2e/shared.ts
@@ -1,7 +1,0 @@
-const page = {
-  goto: (): Promise<void> => Promise.resolve(),
-  on: (): Promise<void> => Promise.resolve(),
-  waitForSelector: (): Promise<void> => Promise.resolve(),
-};
-
-export { page };

--- a/tests/integration/fr-auth.data.ts
+++ b/tests/integration/fr-auth.data.ts
@@ -1,14 +1,17 @@
-export const jsonResponse = {
+import { CallbackType } from '../../src/auth/enums';
+import { Step } from '../../src/auth/interfaces';
+
+export const jsonResponse: Step = {
   authId: 'unused',
   callbacks: [
     {
-      type: 'NameCallback',
+      type: CallbackType.NameCallback,
       output: [{ name: 'prompt', value: 'User Name' }],
       input: [{ name: 'IDToken1', value: '' }],
       _id: 0,
     },
     {
-      type: 'PasswordCallback',
+      type: CallbackType.PasswordCallback,
       output: [{ name: 'prompt', value: 'Password' }],
       input: [{ name: 'IDToken2', value: '' }],
       _id: 1,
@@ -16,15 +19,16 @@ export const jsonResponse = {
   ],
   stage: 'UsernamePassword',
 };
+
 export const rawResponse = {
   body: {},
   bodyUsed: true,
   headers: {
-    get() {
+    get(): string {
       return 'application/json';
     },
   },
-  json() {
+  json(): Step {
     return jsonResponse;
   },
   ok: true,
@@ -36,6 +40,7 @@ export const rawResponse = {
     // eslint-disable-next-line max-len
     'https://openam-devjustin2.forgeblocks.com/am/json/realms/root/authenticate?authIndexType=service&authIndexValue=UsernamePassword',
 };
+
 export const loginSubmission = {
   payload: {
     authId: 'unused',


### PR DESCRIPTION
- Fixed non-relative import and exported additional modules
- Refactored `FRCallback.getOutputByName()` to generic and accepted a default value
- Fixes linter warnings mostly related to use of `any` and functions that don't specify a return type
- Moved some private functions to "helper" files to avoid "use of N before it's defined" linter warnings