### PR TITLE
Fixes CSRF issues

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'url';
 import Config, { ConfigOptions, ServerConfig } from '../config';
+import { REQUESTED_WITH } from '../shared/constants';
 import { getRealmUrlPath } from '../util/realm';
 import { withTimeout } from '../util/timeout';
 import { Step } from './interfaces';
@@ -44,6 +45,7 @@ abstract class Auth {
         accept: 'application/json',
         'accept-api-version': 'protocol=1.0,resource=2.1',
         'content-type': 'application/json',
+        'x-requested-with': REQUESTED_WITH,
       },
       method: 'POST',
     };

--- a/src/session-manager/index.ts
+++ b/src/session-manager/index.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'url';
 import Config, { ConfigOptions } from '../config/index';
+import { REQUESTED_WITH } from '../shared/constants';
 import { isOkOr4xx } from '../util/http';
 import { getRealmUrlPath } from '../util/realm';
 import { withTimeout } from '../util/timeout';
@@ -15,6 +16,10 @@ abstract class SessionManager {
     const { realmPath, serverConfig } = Config.get(options);
     const init: RequestInit = {
       credentials: 'include',
+      headers: {
+        'accept-api-version': 'protocol=1.0,resource=2.0',
+        'x-requested-with': REQUESTED_WITH,
+      },
       method: 'POST',
     };
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,0 +1,3 @@
+const REQUESTED_WITH = 'forgerock-sdk';
+
+export { REQUESTED_WITH };


### PR DESCRIPTION
Some AM endpoints require headers to be present when the CSRF filter is enabled.  This adds those headers to relevant endpoints.

https://backstage.forgerock.com/docs/am/6.5/dev-guide/#rest-CSRF