### PR TITLE
Makes some callback properties optional

### DIFF
--- a/src/auth/interfaces.ts
+++ b/src/auth/interfaces.ts
@@ -58,8 +58,8 @@ interface PolicyParams {
  * Represents the authentication tree API callback schema.
  */
 interface Callback {
-  _id: number;
-  input: NameValue[];
+  _id?: number;
+  input?: NameValue[];
   output: NameValue[];
   type: CallbackType;
 }

--- a/src/fr-auth/callbacks/index.ts
+++ b/src/fr-auth/callbacks/index.ts
@@ -57,7 +57,10 @@ class FRCallback {
     return output ? (output.value as T) : defaultValue;
   }
 
-  private getArrayElement(array: NameValue[], selector: number | string = 0): NameValue {
+  private getArrayElement(
+    array: NameValue[] | undefined,
+    selector: number | string = 0,
+  ): NameValue {
     if (array === undefined) {
       throw new Error(`No NameValue array was provided to search (selector ${selector})`);
     }

--- a/src/fr-auth/callbacks/kba-create-callback.ts
+++ b/src/fr-auth/callbacks/kba-create-callback.ts
@@ -41,6 +41,10 @@ class KbaCreateCallback extends FRCallback {
   }
 
   private setValue(type: 'question' | 'answer', value: string): void {
+    if (!this.payload.input) {
+      throw new Error('KBA payload is missing input');
+    }
+
     const input = this.payload.input.find((x) => x.name.endsWith(type));
     if (!input) {
       throw new Error(`No input has name ending in "${type}"`);


### PR DESCRIPTION
Callback properties `_id` and `input` are not always present.  This updates the interface to reflect that.