### PR TITLE
Adds ability to append querystring params to auth tree urls

### DIFF
--- a/src/auth/interfaces.ts
+++ b/src/auth/interfaces.ts
@@ -1,3 +1,5 @@
+import { ConfigOptions } from '../config/interfaces';
+import { StringDict } from '../shared/interfaces';
 import { CallbackType } from './enums';
 
 /**
@@ -25,6 +27,14 @@ interface StepDetail {
   failedPolicyRequirements?: FailedPolicyRequirement[];
   failureUrl?: string;
   result?: boolean;
+}
+
+/**
+ * Represents configuration overrides used when requesting the next
+ * step in an authentication tree.
+ */
+interface StepOptions extends ConfigOptions {
+  query?: StringDict<string>;
 }
 
 /**
@@ -80,4 +90,5 @@ export {
   PolicyRequirement,
   Step,
   StepDetail,
+  StepOptions,
 };

--- a/src/fr-auth/index.ts
+++ b/src/fr-auth/index.ts
@@ -1,5 +1,5 @@
 import Auth from '../auth/index';
-import { ConfigOptions } from '../config';
+import { StepOptions } from '../auth/interfaces';
 import FRLoginFailure from './fr-login-failure';
 import FRLoginSuccess from './fr-login-success';
 import FRStep from './fr-step';
@@ -42,7 +42,7 @@ abstract class FRAuth {
    */
   public static async next(
     previousStep?: FRStep,
-    options?: ConfigOptions,
+    options?: StepOptions,
   ): Promise<FRStep | FRLoginSuccess | FRLoginFailure> {
     const nextPayload = await Auth.next(previousStep ? previousStep.payload : undefined, options);
 

--- a/src/oauth2-client/index.ts
+++ b/src/oauth2-client/index.ts
@@ -1,5 +1,5 @@
 import Config, { ConfigOptions } from '../config/index';
-import { NameValue } from '../shared/interfaces';
+import { StringDict } from '../shared/interfaces';
 import { Noop } from '../shared/types';
 import TokenStorage from '../token-storage';
 import { isOkOr4xx } from '../util/http';
@@ -26,7 +26,7 @@ abstract class OAuth2Client {
     const { serverConfig, clientId, redirectUri, scope } = Config.get(options);
 
     /* eslint-disable @typescript-eslint/camelcase */
-    const requestParams: NameValue<string | undefined> = {
+    const requestParams: StringDict<string | undefined> = {
       client_id: clientId,
       redirect_uri: redirectUri,
       response_type: options.responseType,
@@ -91,7 +91,7 @@ abstract class OAuth2Client {
     const { clientId, redirectUri } = Config.get(options);
 
     /* eslint-disable @typescript-eslint/camelcase */
-    const requestParams: NameValue<string | undefined> = {
+    const requestParams: StringDict<string | undefined> = {
       client_id: clientId,
       code: options.authorizationCode,
       grant_type: 'authorization_code',
@@ -121,7 +121,7 @@ abstract class OAuth2Client {
       const message =
         typeof responseBody === 'string'
           ? `Expected 200, received ${response.status}`
-          : this.parseError(responseBody as NameValue<unknown>);
+          : this.parseError(responseBody as StringDict<unknown>);
       throw new Error(message);
     }
 
@@ -156,7 +156,7 @@ abstract class OAuth2Client {
   public static async endSession(options?: ConfigOptions): Promise<void> {
     const { idToken } = await TokenStorage.get();
 
-    const query: NameValue<string | undefined> = {};
+    const query: StringDict<string | undefined> = {};
     if (idToken) {
       // eslint-disable-next-line @typescript-eslint/camelcase
       query.id_token_hint = idToken;
@@ -191,7 +191,7 @@ abstract class OAuth2Client {
 
   private static async request(
     path: string,
-    query?: NameValue<string | undefined>,
+    query?: StringDict<string | undefined>,
     includeToken?: boolean,
     init?: RequestInit,
     options?: ConfigOptions,
@@ -223,7 +223,7 @@ abstract class OAuth2Client {
     return await response.text();
   }
 
-  private static parseError(json: NameValue<unknown>): string | undefined {
+  private static parseError(json: StringDict<unknown>): string | undefined {
     if (json) {
       if (json.error && json.error_description) {
         return `${json.error}: ${json.error_description}`;
@@ -237,7 +237,7 @@ abstract class OAuth2Client {
 
   private static getUrl(
     path: string,
-    query?: NameValue<string | undefined>,
+    query?: StringDict<string | undefined>,
     options?: ConfigOptions,
   ): string {
     const { realmPath, serverConfig } = Config.get(options);

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -1,4 +1,4 @@
-interface NameValue<T> {
+interface StringDict<T> {
   [name: string]: T;
 }
 
@@ -8,4 +8,4 @@ interface Tokens {
   refreshToken?: string;
 }
 
-export { NameValue, Tokens };
+export { StringDict, Tokens };

--- a/src/util/url.ts
+++ b/src/util/url.ts
@@ -1,4 +1,4 @@
-import { NameValue } from '../shared/interfaces';
+import { StringDict } from '../shared/interfaces';
 
 /**
  * Returns the base URL including protocol, hostname and any non-standard port.
@@ -27,14 +27,14 @@ function resolve(baseUrl: string, path: string): string {
   return `${getBaseUrl(url)}${newPath}`;
 }
 
-function parseQuery(fullUrl: string): NameValue<string> {
+function parseQuery(fullUrl: string): StringDict<string> {
   const url = new URL(fullUrl);
-  const query: NameValue<string> = {};
+  const query: StringDict<string> = {};
   url.searchParams.forEach((v, k) => (query[k] = v));
   return query;
 }
 
-function stringify(data: NameValue<string | undefined>): string {
+function stringify(data: StringDict<string | undefined>): string {
   const pairs = [];
   for (const k in data) {
     if (data[k]) {


### PR DESCRIPTION
One node type used for email verification during a "change password" tree leverages a querystring parameter named `suspendedId` to resume the tree when the user clicks a link in the verification email.

This change allows app developers to pass this and other name/value pairs to the SDK to be added to the constructed URL.