### PR TITLE
Feature: increase default timeout

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,4 +1,4 @@
 /** @hidden */
-const DEFAULT_TIMEOUT = 5000;
+const DEFAULT_TIMEOUT = 60 * 1000;
 
 export { DEFAULT_TIMEOUT };


### PR DESCRIPTION
This increases the default timeout to 60 seconds, which will help in lower latency environments.