### PR TITLE
Fix (IDM nodes): fix policies typing; add setValidateOnly method

### DIFF
--- a/src/fr-auth/callbacks/attribute-input-callback.ts
+++ b/src/fr-auth/callbacks/attribute-input-callback.ts
@@ -1,5 +1,6 @@
 import FRCallback from '.';
 import { Callback, PolicyRequirement } from '../../auth/interfaces';
+import { StringDict } from 'shared/interfaces';
 
 /**
  * Represents a callback used to collect attributes.
@@ -45,8 +46,15 @@ class AttributeInputCallback<T extends string | boolean> extends FRCallback {
   /**
    * Gets the callback's applicable policies.
    */
-  public getPolicies(): string[] {
-    return this.getOutputByName<string[]>('policies', []);
+  public getPolicies(): StringDict<any> {
+    return this.getOutputByName<StringDict<any>>('policies', {});
+  }
+
+  /**
+   * Set if validating value only.
+   */
+  public setValidateOnly(value: boolean): void {
+    this.setInputValue(value, /validateOnly/);
   }
 
   /**

--- a/src/fr-auth/callbacks/index.ts
+++ b/src/fr-auth/callbacks/index.ts
@@ -32,7 +32,7 @@ class FRCallback {
    *
    * @param selector The index position or name of the desired element
    */
-  public setInputValue(value: unknown, selector: number | string = 0): void {
+  public setInputValue(value: unknown, selector: number | string | RegExp = 0): void {
     this.getArrayElement(this.payload.input, selector).value = value;
   }
 
@@ -59,7 +59,7 @@ class FRCallback {
 
   private getArrayElement(
     array: NameValue[] | undefined,
-    selector: number | string = 0,
+    selector: number | string | RegExp = 0,
   ): NameValue {
     if (array === undefined) {
       throw new Error(`No NameValue array was provided to search (selector ${selector})`);
@@ -74,6 +74,15 @@ class FRCallback {
 
     if (typeof selector === 'string') {
       const input = array.find((x) => x.name === selector);
+      if (!input) {
+        throw new Error(`Missing callback input entry "${selector}"`);
+      }
+      return input;
+    }
+
+    // Duck typing for RegEx
+    if (typeof selector === 'object' && selector.test && selector.exec) {
+      const input = array.find((x) => selector.test(x.name));
       if (!input) {
         throw new Error(`Missing callback input entry "${selector}"`);
       }

--- a/src/fr-auth/callbacks/validated-create-password-callback.test.ts
+++ b/src/fr-auth/callbacks/validated-create-password-callback.test.ts
@@ -1,28 +1,14 @@
 import { CallbackType } from '../../auth/enums';
 import { Callback } from '../../auth/interfaces';
-import AttributeInputCallback from './attribute-input-callback';
+import ValidatedCreatePasswordCallback from './validated-create-password-callback';
 
-describe('AttributeInputCallback', () => {
+describe('ValidatedCreatePasswordCallback', () => {
   const payload: Callback = {
-    _id: 0,
-    input: [
-      {
-        name: 'IDToken0',
-        value: '',
-      },
-      {
-        name: 'IDToken0validateOnly',
-        value: false,
-      },
-    ],
+    type: CallbackType.ValidatedCreatePasswordCallback,
     output: [
       {
-        name: 'name',
-        value: 'givenName',
-      },
-      {
-        name: 'prompt',
-        value: 'First Name:',
+        name: 'echoOn',
+        value: false,
       },
       {
         name: 'required',
@@ -32,7 +18,7 @@ describe('AttributeInputCallback', () => {
         name: 'policies',
         value: {
           policyRequirements: ['a', 'b'],
-          name: 'givenName',
+          name: 'password',
           policies: [],
         },
       },
@@ -44,27 +30,40 @@ describe('AttributeInputCallback', () => {
         name: 'validateOnly',
         value: false,
       },
+      {
+        name: 'prompt',
+        value: 'Password',
+      },
     ],
-    type: CallbackType.StringAttributeInputCallback,
+    input: [
+      {
+        name: 'IDToken2',
+        value: '',
+      },
+      {
+        name: 'IDToken2validateOnly',
+        value: false,
+      },
+    ],
+    _id: 1,
   };
 
   it('reads/writes basic properties with "validate only"', () => {
-    const cb = new AttributeInputCallback<string>(payload);
-    cb.setValue('Clark');
+    const cb = new ValidatedCreatePasswordCallback(payload);
+    cb.setPassword('abcd123');
     cb.setValidateOnly(true);
 
-    expect(cb.getType()).toBe('StringAttributeInputCallback');
-    expect(cb.getName()).toBe('givenName');
-    expect(cb.getPrompt()).toBe('First Name:');
+    expect(cb.getType()).toBe('ValidatedCreatePasswordCallback');
+    expect(cb.getPrompt()).toBe('Password');
     expect(cb.isRequired()).toBe(true);
     expect(cb.getPolicies().policyRequirements).toStrictEqual(['a', 'b']);
     expect(cb.getFailedPolicies()).toStrictEqual(['c', 'd']);
-    expect(cb.getInputValue()).toBe('Clark');
+    expect(cb.payload.input[0].value).toBe('abcd123');
     expect(cb.payload.input[1].value).toBe(true);
   });
 
   it('writes validate only to `false` for submission', () => {
-    const cb = new AttributeInputCallback<string>(payload);
+    const cb = new ValidatedCreatePasswordCallback(payload);
     cb.setValidateOnly(false);
     expect(cb.payload.input[1].value).toBe(false);
   });

--- a/src/fr-auth/callbacks/validated-create-password-callback.ts
+++ b/src/fr-auth/callbacks/validated-create-password-callback.ts
@@ -1,5 +1,6 @@
 import FRCallback from '.';
 import { Callback, PolicyRequirement } from '../../auth/interfaces';
+import { StringDict } from 'shared/interfaces';
 
 /**
  * Represents a callback used to collect a valid platform password.
@@ -22,8 +23,8 @@ class ValidatedCreatePasswordCallback extends FRCallback {
   /**
    * Gets the callback's applicable policies.
    */
-  public getPolicies(): string[] {
-    return this.getOutputByName<string[]>('policies', []);
+  public getPolicies(): StringDict<any> {
+    return this.getOutputByName<StringDict<any>>('policies', {});
   }
 
   /**
@@ -45,6 +46,13 @@ class ValidatedCreatePasswordCallback extends FRCallback {
    */
   public setPassword(password: string): void {
     this.setInputValue(password);
+  }
+
+  /**
+   * Set if validating value only.
+   */
+  public setValidateOnly(value: boolean): void {
+    this.setInputValue(value, /validateOnly/);
   }
 }
 

--- a/src/fr-auth/callbacks/validated-create-username-callback.test.ts
+++ b/src/fr-auth/callbacks/validated-create-username-callback.test.ts
@@ -1,28 +1,14 @@
 import { CallbackType } from '../../auth/enums';
 import { Callback } from '../../auth/interfaces';
-import AttributeInputCallback from './attribute-input-callback';
+import ValidatedCreateUsernameCallback from './validated-create-username-callback';
 
-describe('AttributeInputCallback', () => {
+describe('ValidatedCreateUsernameCallback', () => {
   const payload: Callback = {
-    _id: 0,
-    input: [
-      {
-        name: 'IDToken0',
-        value: '',
-      },
-      {
-        name: 'IDToken0validateOnly',
-        value: false,
-      },
-    ],
+    type: CallbackType.ValidatedCreateUsernameCallback,
     output: [
       {
-        name: 'name',
-        value: 'givenName',
-      },
-      {
-        name: 'prompt',
-        value: 'First Name:',
+        name: 'echoOn',
+        value: false,
       },
       {
         name: 'required',
@@ -32,7 +18,7 @@ describe('AttributeInputCallback', () => {
         name: 'policies',
         value: {
           policyRequirements: ['a', 'b'],
-          name: 'givenName',
+          name: 'username',
           policies: [],
         },
       },
@@ -44,27 +30,40 @@ describe('AttributeInputCallback', () => {
         name: 'validateOnly',
         value: false,
       },
+      {
+        name: 'prompt',
+        value: 'Username',
+      },
     ],
-    type: CallbackType.StringAttributeInputCallback,
+    input: [
+      {
+        name: 'IDToken2',
+        value: '',
+      },
+      {
+        name: 'IDToken2validateOnly',
+        value: false,
+      },
+    ],
+    _id: 1,
   };
 
   it('reads/writes basic properties with "validate only"', () => {
-    const cb = new AttributeInputCallback<string>(payload);
-    cb.setValue('Clark');
+    const cb = new ValidatedCreateUsernameCallback(payload);
+    cb.setName('abcd123');
     cb.setValidateOnly(true);
 
-    expect(cb.getType()).toBe('StringAttributeInputCallback');
-    expect(cb.getName()).toBe('givenName');
-    expect(cb.getPrompt()).toBe('First Name:');
+    expect(cb.getType()).toBe('ValidatedCreateUsernameCallback');
+    expect(cb.getPrompt()).toBe('Username');
     expect(cb.isRequired()).toBe(true);
     expect(cb.getPolicies().policyRequirements).toStrictEqual(['a', 'b']);
     expect(cb.getFailedPolicies()).toStrictEqual(['c', 'd']);
-    expect(cb.getInputValue()).toBe('Clark');
+    expect(cb.payload.input[0].value).toBe('abcd123');
     expect(cb.payload.input[1].value).toBe(true);
   });
 
   it('writes validate only to `false` for submission', () => {
-    const cb = new AttributeInputCallback<string>(payload);
+    const cb = new ValidatedCreateUsernameCallback(payload);
     cb.setValidateOnly(false);
     expect(cb.payload.input[1].value).toBe(false);
   });

--- a/src/fr-auth/callbacks/validated-create-username-callback.ts
+++ b/src/fr-auth/callbacks/validated-create-username-callback.ts
@@ -1,5 +1,6 @@
 import FRCallback from '.';
 import { Callback, PolicyRequirement } from '../../auth/interfaces';
+import { StringDict } from 'shared/interfaces';
 
 /**
  * Represents a callback used to collect a valid platform username.
@@ -29,8 +30,8 @@ class ValidatedCreateUsernameCallback extends FRCallback {
   /**
    * Gets the callback's applicable policies.
    */
-  public getPolicies(): string[] {
-    return this.getOutputByName<string[]>('policies', []);
+  public getPolicies(): StringDict<any> {
+    return this.getOutputByName<StringDict<any>>('policies', {});
   }
 
   /**
@@ -45,6 +46,13 @@ class ValidatedCreateUsernameCallback extends FRCallback {
    */
   public setName(name: string): void {
     this.setInputValue(name);
+  }
+
+  /**
+   * Set if validating value only.
+   */
+  public setValidateOnly(value: boolean): void {
+    this.setInputValue(value, /validateOnly/);
   }
 }
 

--- a/tests/e2e/app/authn-platform/autoscript.js
+++ b/tests/e2e/app/authn-platform/autoscript.js
@@ -34,7 +34,20 @@
       .from(forgerock.FRAuth.next())
       .pipe(
         rxMergeMap((step) => {
-          console.log('Set values on auth tree callbacks');
+          console.log('Set values on auth tree callbacks for validation only');
+          const unCb = step.getCallbackOfType('ValidatedCreateUsernameCallback');
+          unCb.setName(un);
+          unCb.setValidateOnly(true);
+
+          const pwCb = step.getCallbackOfType('ValidatedCreatePasswordCallback');
+          pwCb.setPassword(pw);
+          pwCb.setValidateOnly(true);
+
+          return forgerock.FRAuth.next(step);
+        }),
+        rxjs.operators.delay(delay),
+        rxMergeMap((step) => {
+          console.log('Set values on auth tree callbacks for submission');
           step.getCallbackOfType('ValidatedCreateUsernameCallback').setName(un);
           step.getCallbackOfType('ValidatedCreatePasswordCallback').setPassword(pw);
           return forgerock.FRAuth.next(step);

--- a/tests/e2e/server/responses.mjs
+++ b/tests/e2e/server/responses.mjs
@@ -96,7 +96,10 @@ export const initialPlatformLogin = {
     {
       type: 'ValidatedCreatePasswordCallback',
       output: [{ name: 'prompt', value: 'Password' }],
-      input: [{ name: 'IDToken2', value: '' }],
+      input: [
+        { name: 'IDToken2', value: '' },
+        { name: 'IDToken2validateOnly', value: false },
+      ],
       _id: 1,
     },
   ],


### PR DESCRIPTION
**Summary**:

Update IDM callback handlers to handle proper type for `policies` property as well as a set method for the `validateOnly` property.

**Details**:

- Changed `policies` type from array to object
- Added `setValidateOnly` method to callbacks
- Added unit tests for IDM password and username callbacks
- Added step to e2e test for platform login that included validation only