### PR TITLE
Fix (webauthn): conditionally set key-value pairs options obj

### DIFF
--- a/src/fr-webauthn/index.ts
+++ b/src/fr-webauthn/index.ts
@@ -299,11 +299,13 @@ abstract class FRWebAuthn {
   ): PublicKeyCredentialRequestOptions {
     const { allowCredentials, challenge, relyingPartyId, timeout, userVerification } = metadata;
     const rpId = parseRelyingPartyId(relyingPartyId);
+    const allowCredentialsValue = parseCredentials(allowCredentials);
 
     return {
-      allowCredentials: parseCredentials(allowCredentials),
       challenge: Uint8Array.from(atob(challenge), (c) => c.charCodeAt(0)).buffer,
       timeout,
+      // only add key-value pair if proper value is provided
+      ...(allowCredentialsValue && { allowCredentials: allowCredentialsValue }),
       ...(userVerification && { userVerification }),
       ...(rpId && { rpId }),
     };
@@ -334,6 +336,7 @@ abstract class FRWebAuthn {
       timeout,
       userId,
       userName,
+      displayName,
     } = metadata;
     const rpId = parseRelyingPartyId(relyingPartyId);
     const rp: RelyingParty = {
@@ -349,7 +352,7 @@ abstract class FRWebAuthn {
       rp,
       timeout,
       user: {
-        displayName: userName,
+        displayName: displayName,
         id: Int8Array.from(userId.split('').map((c: string) => c.charCodeAt(0))),
         name: userName,
       },

--- a/src/fr-webauthn/interfaces.ts
+++ b/src/fr-webauthn/interfaces.ts
@@ -61,6 +61,7 @@ interface WebAuthnRegistrationMetadata {
   timeout: number;
   userId: string;
   userName: string;
+  displayName: string;
 }
 
 interface WebAuthnAuthenticationMetadata {

--- a/src/fr-webauthn/script-parser.test.ts
+++ b/src/fr-webauthn/script-parser.test.ts
@@ -1,25 +1,44 @@
 import { parseWebAuthnAuthenticateText, parseWebAuthnRegisterText } from './script-parser';
-import { authenticateInput, registerInput, registerOutput } from './script-text.mock.data';
+import {
+  authenticateInputWithRpidAndAllowCredentials,
+  authenticateInputWithoutRpidAndAllowCredentials,
+  registerInputWithRpid,
+  registerOutputWithRpid,
+  registerInputWithoutRpid,
+  registerOutputWithoutRpid,
+} from './script-text.mock.data';
 
 describe('Parsing of the WebAuthn script type text', () => {
-  it('should parse the WebAuthn authenticate block of text', () => {
-    const obj = parseWebAuthnAuthenticateText(authenticateInput);
+  it('should parse the WebAuthn authenticate block of text with rpid and allow credentials', () => {
+    const obj = parseWebAuthnAuthenticateText(authenticateInputWithRpidAndAllowCredentials);
     expect(obj.allowCredentials[0].type).toBe('public-key');
     expect(obj.allowCredentials[0].id.byteLength > 0).toBe(true);
     expect(obj.challenge.byteLength > 0).toBe(true);
     expect(obj.timeout).toBe(60000);
+    expect(obj.rpId).toBe('example.com');
   });
 
-  it('should parse the WebAuthn register block of text', () => {
-    const obj = parseWebAuthnRegisterText(registerInput);
-    expect(obj.attestation).toBe(registerOutput.attestation);
-    expect(obj.authenticatorSelection).toStrictEqual(registerOutput.authenticatorSelection);
+  it('should parse the WebAuthn authenticate block of text', () => {
+    const obj = parseWebAuthnAuthenticateText(authenticateInputWithoutRpidAndAllowCredentials);
+    expect(obj.allowCredentials).toBe(undefined);
+    expect(obj.rpId).toBe(undefined);
+  });
+
+  it('should parse the WebAuthn register block of text with rpid', () => {
+    const obj = parseWebAuthnRegisterText(registerInputWithRpid);
+    expect(obj.attestation).toBe(registerOutputWithRpid.attestation);
+    expect(obj.authenticatorSelection).toStrictEqual(registerOutputWithRpid.authenticatorSelection);
     expect(obj.challenge.byteLength > 0).toBe(true);
-    expect(obj.pubKeyCredParams).toStrictEqual(registerOutput.pubKeyCredParams);
-    expect(obj.rp).toStrictEqual(registerOutput.rp);
-    expect(obj.timeout).toBe(registerOutput.timeout);
-    expect(obj.user.displayName).toStrictEqual(registerOutput.user.displayName);
-    expect(obj.user.name).toBe(registerOutput.user.name);
+    expect(obj.pubKeyCredParams).toStrictEqual(registerOutputWithRpid.pubKeyCredParams);
+    expect(obj.rp).toStrictEqual(registerOutputWithRpid.rp);
+    expect(obj.timeout).toBe(registerOutputWithRpid.timeout);
+    expect(obj.user.displayName).toStrictEqual(registerOutputWithRpid.user.displayName);
+    expect(obj.user.name).toBe(registerOutputWithRpid.user.name);
     expect(obj.user.id.byteLength > 0).toBe(true);
+  });
+
+  it('should parse the WebAuthn register block of text withOUT rpid', () => {
+    const obj = parseWebAuthnRegisterText(registerInputWithoutRpid);
+    expect(obj.rp).toStrictEqual(registerOutputWithoutRpid.rp);
   });
 });

--- a/src/fr-webauthn/script-text.mock.data.ts
+++ b/src/fr-webauthn/script-text.mock.data.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-const authenticateInput = `/*
+const authenticateInputWithRpidAndAllowCredentials = `/*
 * Copyright 2018-2020 ForgeRock AS. All Rights Reserved
 *
 * Use of this code requires a commercial software license with ForgeRock AS.
@@ -13,6 +13,7 @@ if (!window.PublicKeyCredential) {
 }
 
 var options = {
+   rpId: "example.com",
    challenge: new Int8Array([14, 126, -110, -74, 64, -66, 20, -56, -40, -28, 116, -61, -128, -20, 72, 24, 42, 79, -105, 94, -84, -12, -17, -97, 105, -31, -30, 92, 55, 67, -83, 65]).buffer,
    timeout: 60000,
    allowCredentials: [{ "type": "public-key", "id": new Int8Array([-107, 93, 68, -67, -5, 107, 18, 16, -25, -30, 80, 103, -75, -53, -2, -95, 102, 42, 47, 126, -1, 85, 93, 45, -85, 8, -108, 107, 47, -25, 66, 12, -96, 81, 104, -127, 26, -59, -69, -23, 75, 89, 58, 124, -93, 4, 28, -128, 121, 35, 39, 103, -86, -86, 123, -67, -7, -4, 79, -49, 127, -19, 7, 4]).buffer }]
@@ -32,24 +33,39 @@ navigator.credentials.get({ "publicKey" : options })
        document.getElementById("loginButton_0").click();
    });`;
 
-// Currently not used
-const authenticateOuput = {
-  allowCredentials: [
-    {
-      type: 'public-key',
-      id: [
-        /* don't directly test */
-      ],
-    },
-  ],
-  challenge: [
-    /* don't directly test */
-  ],
-  timeout: 60000,
+const authenticateInputWithoutRpidAndAllowCredentials = `/*
+* Copyright 2018-2020 ForgeRock AS. All Rights Reserved
+*
+* Use of this code requires a commercial software license with ForgeRock AS.
+* or with one of its affiliates. All use shall be exclusively subject
+* to such license between the licensee and ForgeRock AS.
+*/
+
+if (!window.PublicKeyCredential) {
+   document.getElementById('webAuthnOutcome').value = "unsupported";
+   document.getElementById("loginButton_0").click();
+}
+
+var options = {
+   challenge: new Int8Array([14, 126, -110, -74, 64, -66, 20, -56, -40, -28, 116, -61, -128, -20, 72, 24, 42, 79, -105, 94, -84, -12, -17, -97, 105, -31, -30, 92, 55, 67, -83, 65]).buffer,
+   timeout: 60000,
 };
 
-/* eslint-disable max-len */
-const registerInput = `/*
+navigator.credentials.get({ "publicKey" : options })
+   .then(function (assertion) {
+       var clientData = String.fromCharCode.apply(null, new Uint8Array(assertion.response.clientDataJSON));
+       var authenticatorData = new Int8Array(assertion.response.authenticatorData).toString();
+       var signature = new Int8Array(assertion.response.signature).toString();
+       var rawId = assertion.id;
+       var userHandle = String.fromCharCode.apply(null, new Uint8Array(assertion.response.userHandle));
+       document.getElementById('webAuthnOutcome').value = clientData + "::" + authenticatorData + "::" + signature + "::" + rawId + "::" + userHandle;
+       document.getElementById("loginButton_0").click();
+   }).catch(function (err) {
+       document.getElementById('webAuthnOutcome').value = "ERROR" + "::" + err;
+       document.getElementById("loginButton_0").click();
+   });`;
+
+const registerInputWithRpid = `/*
  * Copyright 2018-2020 ForgeRock AS. All Rights Reserved
  *
  * Use of this code requires a commercial software license with ForgeRock AS.
@@ -66,14 +82,14 @@ var publicKey = {
     challenge: new Int8Array([102, -15, -36, -101, -95, 10, -20, 39, 29, 70, 122, 25, 53, 83, 72, -38, 83, -92, 31, -30, 26, -94, 92, -94, -83, 7, 82, -66, -125, -95, -4, -75]).buffer,
     // Relying Party:
     rp: {
-        id: "user.example.com",
+        id: "example.com",
         name: "ForgeRock"
     },
     // User:
     user: {
         id: Uint8Array.from("NTdhNWI0ZTQtNjk5OS00YjQ1LWJmODYtYTRmMmU1ZDRiNjI5", function (c) { return c.charCodeAt(0) }),
         name: "57a5b4e4-6999-4b45-bf86-a4f2e5d4b629",
-        displayName: "57a5b4e4-6999-4b45-bf86-a4f2e5d4b629"
+        displayName: "Bob Tester"
     },
     pubKeyCredParams: [ { "type": "public-key", "alg": -257 }, { "type": "public-key", "alg": -7 } ],
     attestation: "none",
@@ -94,21 +110,20 @@ navigator.credentials.create({publicKey: publicKey})
         document.getElementById("loginButton_0").click();
     });`;
 
-const registerOutput = {
+const registerOutputWithRpid = {
   attestation: 'none',
   authenticatorSelection: { userVerification: 'preferred' },
   challenge: [
     /* don't directly test */
   ],
-  excludeCredentials: [],
   pubKeyCredParams: [
     { type: 'public-key', alg: -257 },
     { type: 'public-key', alg: -7 },
   ],
-  rp: { id: 'user.example.com', name: 'ForgeRock' },
+  rp: { id: 'example.com', name: 'ForgeRock' },
   timeout: 60000,
   user: {
-    displayName: '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629',
+    displayName: 'Bob Tester',
     id: [
       /* don't directly test */
     ],
@@ -116,4 +131,76 @@ const registerOutput = {
   },
 };
 
-export { authenticateInput, authenticateOuput, registerInput, registerOutput };
+const registerInputWithoutRpid = `/*
+ * Copyright 2018-2020 ForgeRock AS. All Rights Reserved
+ *
+ * Use of this code requires a commercial software license with ForgeRock AS.
+ * or with one of its affiliates. All use shall be exclusively subject
+ * to such license between the licensee and ForgeRock AS.
+ */
+
+if (!window.PublicKeyCredential) {
+    document.getElementById('webAuthnOutcome').value = "unsupported";
+    document.getElementById("loginButton_0").click();
+}
+
+var publicKey = {
+    challenge: new Int8Array([102, -15, -36, -101, -95, 10, -20, 39, 29, 70, 122, 25, 53, 83, 72, -38, 83, -92, 31, -30, 26, -94, 92, -94, -83, 7, 82, -66, -125, -95, -4, -75]).buffer,
+    // Relying Party:
+    rp: {
+        name: "ForgeRock"
+    },
+    // User:
+    user: {
+        id: Uint8Array.from("NTdhNWI0ZTQtNjk5OS00YjQ1LWJmODYtYTRmMmU1ZDRiNjI5", function (c) { return c.charCodeAt(0) }),
+        name: "57a5b4e4-6999-4b45-bf86-a4f2e5d4b629",
+        displayName: "Bob Tester"
+    },
+    pubKeyCredParams: [ { "type": "public-key", "alg": -257 }, { "type": "public-key", "alg": -7 } ],
+    attestation: "none",
+    timeout: 60000,
+    excludeCredentials: [],
+    authenticatorSelection: {"userVerification":"preferred"}
+};
+
+navigator.credentials.create({publicKey: publicKey})
+    .then(function (newCredentialInfo) {
+        var rawId = newCredentialInfo.id;
+        var clientData = String.fromCharCode.apply(null, new Uint8Array(newCredentialInfo.response.clientDataJSON));
+        var keyData = new Int8Array(newCredentialInfo.response.attestationObject).toString();
+        document.getElementById('webAuthnOutcome').value = clientData + "::" + keyData + "::" + rawId;
+        document.getElementById("loginButton_0").click();
+    }).catch(function (err) {
+        document.getElementById('webAuthnOutcome').value = "ERROR" + "::" + err;
+        document.getElementById("loginButton_0").click();
+    });`;
+
+const registerOutputWithoutRpid = {
+  attestation: 'none',
+  authenticatorSelection: { userVerification: 'preferred' },
+  challenge: [
+    /* don't directly test */
+  ],
+  pubKeyCredParams: [
+    { type: 'public-key', alg: -257 },
+    { type: 'public-key', alg: -7 },
+  ],
+  rp: { name: 'ForgeRock' },
+  timeout: 60000,
+  user: {
+    displayName: 'Bob Tester',
+    id: [
+      /* don't directly test */
+    ],
+    name: '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629',
+  },
+};
+
+export {
+  authenticateInputWithRpidAndAllowCredentials,
+  authenticateInputWithoutRpidAndAllowCredentials,
+  registerInputWithRpid,
+  registerOutputWithRpid,
+  registerInputWithoutRpid,
+  registerOutputWithoutRpid,
+};


### PR DESCRIPTION
**Summary**:

AM conditionally sets a few key-value pairs for WebAuthn credential options object. When parsing the incoming callbacks, the SDK needed to align with conditions.

**Details**:

`relyingPartyId` and `allowCredentials` needed to be conditionally set in options object in order to avoiding DOM errors and continue iterating the AM trees.