### PR TITLE
Feat (webauthn): support usernameless login with username on device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [unreleased]
+
+### Added
+
+- Support for "usernameless" login (storing username on WebAuthn capable tech)
+- Support for the recovery code display node and the parsing of the codes from the TextOutputCallback
+- Support for user verification property for WebAuthn
+- Updated support for new IDM nodes for registration and self-service
+
+### Fixed
+
+- Conditionally set user verification, relying party and allow credentials to WebAuthn key options
+- Ensure display name and username are correctly parsed and added to WebAuthn key options
+
 ## [2.0.0] - 2020-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </a>
   <h2 align="center">ForgeRock SDK for JavaScript</h2>
   <p align="center">
-    <a href="./blob/master/CHANGELOG.md">Change Log</a>
+    <a href="https://github.com/ForgeRock/forgerock-javascript-sdk/blob/master/CHANGELOG.md">Change Log</a>
     ·
     <a href="#support">Support</a>
     ·

--- a/package-lock.json
+++ b/package-lock.json
@@ -1161,9 +1161,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
-      "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
+      "version": "14.0.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.26.tgz",
+      "integrity": "sha512-W+fpe5s91FBGE0pEa0lnqGLL4USgpLgs4nokw16SrBBco/gQxuua7KnArSEOd5iaMqbbSHV10vUDkJYJJqpXKA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1535,9 +1535,9 @@
       "dev": true
     },
     "ajv-keywords": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.1.tgz",
-      "integrity": "sha512-KWcq3xN8fDjSB+IMoh2VaXVhRI0BBGxoYp3rx7Pkb6z0cFjYR9Q9l4yZqqals0/zsioCmocC5H6UvsGD4MoIBA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true
     },
     "ansi-colors": {
@@ -3684,9 +3684,9 @@
       "dev": true
     },
     "events": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
       "dev": true
     },
     "evp_bytestokey": {
@@ -4074,9 +4074,9 @@
       "dev": true
     },
     "fake-indexeddb": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-3.1.1.tgz",
-      "integrity": "sha512-y3hsVRLVdHb34bG0DcqfgFJ2jYxZ6Jc/Q82QPB/QvUr48ei+WoNG7Ph03J0r5S9dfntwgABLlOpHjn/6WzQA8A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-3.1.2.tgz",
+      "integrity": "sha512-W60eRBrE8r9o/EePyyUc63sr2I/MI9p3zVwLlC1WI1xdmQVqqM6+wec9KDWDz2EZyvJKhrDvy3cGC6hK8L1pfg==",
       "dev": true,
       "requires": {
         "realistic-structured-clone": "^2.0.1",
@@ -4974,9 +4974,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.1.tgz",
-      "integrity": "sha512-b4L09127uVa+9vkMgPpdUQP78ickGbHEQTWeBrQFTJZ4/n2aihWOGS0ZoUqAwjVmfjhq/C76HRzkqwZhK4sBbg==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.2.tgz",
+      "integrity": "sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==",
       "dev": true
     },
     "hmac-drbg": {
@@ -7698,24 +7698,24 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-7.0.1.tgz",
-      "integrity": "sha512-VkzhierE7DBmQEElhTGJIoiZa1oqRijOtgOlsXg32KrJRXsPy0NXFBqWGW/wTswnJlDCs5viRYaqWguqzsKcmg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-7.0.2.tgz",
+      "integrity": "sha512-ux+n4hPVETuTL8+daJXTOC6uKLgMsl1RYfFv7DKRzyvzBapqco0rZZ9g72ZN8VS6V+gvNYHYa/ofcCY8fkJWsA==",
       "dev": true,
       "optional": true,
       "requires": {
         "growly": "^1.3.0",
-        "is-wsl": "^2.1.1",
-        "semver": "^7.2.1",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.2",
         "shellwords": "^0.1.1",
-        "uuid": "^7.0.3",
+        "uuid": "^8.2.0",
         "which": "^2.0.2"
       },
       "dependencies": {
         "uuid": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==",
           "dev": true,
           "optional": true
         }
@@ -8111,9 +8111,9 @@
       }
     },
     "parse-json": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-      "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+      "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -8753,21 +8753,21 @@
       }
     },
     "request-promise-core": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.19"
       }
     },
     "request-promise-native": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
-      "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
       "dev": true,
       "requires": {
-        "request-promise-core": "1.1.3",
+        "request-promise-core": "1.1.4",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       },
@@ -10634,12 +10634,12 @@
       }
     },
     "watchpack": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.2.tgz",
-      "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
+      "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
       "dev": true,
       "requires": {
-        "chokidar": "^3.4.0",
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0",
         "watchpack-chokidar2": "^2.0.0"
@@ -10748,9 +10748,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.43.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
-      "integrity": "sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==",
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.0.tgz",
+      "integrity": "sha512-wAuJxK123sqAw31SpkPiPW3iKHgFUiKvO7E7UZjtdExcsRe3fgav4mvoMM7vvpjLHVoJ6a0Mtp2fzkoA13e0Zw==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
@@ -10761,7 +10761,7 @@
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.1.0",
+        "enhanced-resolve": "^4.3.0",
         "eslint-scope": "^4.0.3",
         "json-parse-better-errors": "^1.0.2",
         "loader-runner": "^2.4.0",
@@ -10774,7 +10774,7 @@
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
         "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.6.1",
+        "watchpack": "^1.7.4",
         "webpack-sources": "^1.4.1"
       },
       "dependencies": {

--- a/src/fr-webauthn/helpers.ts
+++ b/src/fr-webauthn/helpers.ts
@@ -1,13 +1,13 @@
-import { ParsedCredential, ResponseCredential } from './interfaces';
+import { ParsedCredential } from './interfaces';
 
 function ensureArray(arr: RegExpMatchArray | null): string[] {
   return arr || [];
 }
 
-function getClientDataJson(credential: ResponseCredential): string {
+function arrayBufferToString(arrayBuffer: ArrayBuffer): string {
   // https://goo.gl/yabPex - To future-proof, we'll pass along whatever the browser
   // gives us and let AM disregard randomly-injected properties
-  const uint8Array = new Uint8Array(credential.response.clientDataJSON);
+  const uint8Array = new Uint8Array(arrayBuffer);
   const txtDecoder = new TextDecoder();
 
   const json = txtDecoder.decode(uint8Array);
@@ -99,7 +99,7 @@ function parseRelyingPartyId(relyingPartyId: string): string {
 
 export {
   ensureArray,
-  getClientDataJson,
+  arrayBufferToString,
   getIndexOne,
   parseCredentials,
   parseNumberArray,

--- a/src/fr-webauthn/script-parser.test.ts
+++ b/src/fr-webauthn/script-parser.test.ts
@@ -1,8 +1,10 @@
 import { parseWebAuthnAuthenticateText, parseWebAuthnRegisterText } from './script-parser';
 import {
   authenticateInputWithRpidAndAllowCredentials,
+  authenticateInputWithRpidAllowCredentialsAndQuotes,
   authenticateInputWithoutRpidAndAllowCredentials,
   registerInputWithRpid,
+  registerInputWithRpidAndQuotes,
   registerOutputWithRpid,
   registerInputWithoutRpid,
   registerOutputWithoutRpid,
@@ -18,6 +20,15 @@ describe('Parsing of the WebAuthn script type text', () => {
     expect(obj.rpId).toBe('example.com');
   });
 
+  it('should parse the WebAuthn authenticate block of text with quoted keys', () => {
+    const obj = parseWebAuthnAuthenticateText(authenticateInputWithRpidAllowCredentialsAndQuotes);
+    expect(obj.allowCredentials[0].type).toBe('public-key');
+    expect(obj.allowCredentials[0].id.byteLength > 0).toBe(true);
+    expect(obj.challenge.byteLength > 0).toBe(true);
+    expect(obj.timeout).toBe(60000);
+    expect(obj.rpId).toBe('example.com');
+  });
+
   it('should parse the WebAuthn authenticate block of text', () => {
     const obj = parseWebAuthnAuthenticateText(authenticateInputWithoutRpidAndAllowCredentials);
     expect(obj.allowCredentials).toBe(undefined);
@@ -26,6 +37,19 @@ describe('Parsing of the WebAuthn script type text', () => {
 
   it('should parse the WebAuthn register block of text with rpid', () => {
     const obj = parseWebAuthnRegisterText(registerInputWithRpid);
+    expect(obj.attestation).toBe(registerOutputWithRpid.attestation);
+    expect(obj.authenticatorSelection).toStrictEqual(registerOutputWithRpid.authenticatorSelection);
+    expect(obj.challenge.byteLength > 0).toBe(true);
+    expect(obj.pubKeyCredParams).toStrictEqual(registerOutputWithRpid.pubKeyCredParams);
+    expect(obj.rp).toStrictEqual(registerOutputWithRpid.rp);
+    expect(obj.timeout).toBe(registerOutputWithRpid.timeout);
+    expect(obj.user.displayName).toStrictEqual(registerOutputWithRpid.user.displayName);
+    expect(obj.user.name).toBe(registerOutputWithRpid.user.name);
+    expect(obj.user.id.byteLength > 0).toBe(true);
+  });
+
+  it('should parse the WebAuthn register block of text with rpid and quoted keys', () => {
+    const obj = parseWebAuthnRegisterText(registerInputWithRpidAndQuotes);
     expect(obj.attestation).toBe(registerOutputWithRpid.attestation);
     expect(obj.authenticatorSelection).toStrictEqual(registerOutputWithRpid.authenticatorSelection);
     expect(obj.challenge.byteLength > 0).toBe(true);

--- a/src/fr-webauthn/script-parser.ts
+++ b/src/fr-webauthn/script-parser.ts
@@ -5,38 +5,43 @@ function parseWebAuthnRegisterText(text: string): PublicKeyCredentialCreationOpt
   const txtEncoder = new TextEncoder();
 
   // e.g. `attestation: "none"`
-  const attestation = getIndexOne(text.match(/attestation:\s{0,}"(\w+)"/)) as AttestationType;
+  const attestation = getIndexOne(text.match(/attestation"{0,}:\s{0,}"(\w+)"/)) as AttestationType;
   // e.g. `timeout: 60000`
-  const timeout = Number(getIndexOne(text.match(/timeout:\s{0,}(\d+)/)));
-  // e.g. `"userVerification":"preferred"`
+  const timeout = Number(getIndexOne(text.match(/timeout"{0,}:\s{0,}(\d+)/)));
+  // e.g. from 7.0: `"userVerification":"preferred"`
+  // e.g. from 6.5: `userVerification: "preferred"`
   const userVerification = getIndexOne(
-    text.match(/"userVerification":\s{0,}"(\w+)"/),
+    text.match(/userVerification"{0,}:\s{0,}"(\w+)"/),
   ) as UserVerificationType;
+  // e.g. `"requireResidentKey":true`
+  const requireResidentKey = getIndexOne(
+    text.match(/requireResidentKey"{0,}:\s{0,}(\w+)/),
+  ) as string;
 
   // e.g. `rp: {\n id: \"https://user.example.com:3002\",\n name: \"ForgeRock\"\n }`
-  const rp = getIndexOne(text.match(/rp:\s{0,}{([^}]+)}/)).trim();
+  const rp = getIndexOne(text.match(/rp"{0,}:\s{0,}{([^}]+)}/)).trim();
   // e.g. `id: \"example.com\"
-  const rpId = getIndexOne(rp.match(/id:\s{0,}"([^"]*)"/));
+  const rpId = getIndexOne(rp.match(/id"{0,}:\s{0,}"([^"]*)"/));
   // e.g. `name: \"ForgeRock\"`
-  const rpName = getIndexOne(rp.match(/name:\s{0,}"([^"]*)"/));
+  const rpName = getIndexOne(rp.match(/name"{0,}:\s{0,}"([^"]*)"/));
 
   // e.g. `user: {\n id: Uint8Array.from(\"NTdhN...RiNjI5\",
   // function (c) { return c.charCodeAt(0) }),\n
   // name: \"57a5b4e4-...-a4f2e5d4b629\",\n
   // displayName: \"57a5b4e4-...-a4f2e5d4b629\"\n }`
-  const user = getIndexOne(text.match(/user:\s{0,}{([^]{0,})},/)).trim();
+  const user = getIndexOne(text.match(/user"{0,}:\s{0,}{([^]{0,})},/)).trim();
   // e.g `id: Uint8Array.from(\"NTdhN...RiNjI5\",`
-  const userId = getIndexOne(user.match(/id:\s{0,}Uint8Array.from\("([^"]+)"/));
+  const userId = getIndexOne(user.match(/id"{0,}:\s{0,}Uint8Array.from\("([^"]+)"/));
   // e.g. `name: \"57a5b4e4-...-a4f2e5d4b629\",`
-  const userName = getIndexOne(user.match(/name:\s{0,}"([\d\w._-]+)"/));
+  const userName = getIndexOne(user.match(/name"{0,}:\s{0,}"([\d\w._-]+)"/));
   // e.g. `displayName: \"57a5b4e4-...-a4f2e5d4b629\"`
-  const userDisplayName = getIndexOne(user.match(/displayName:\s{0,}"([\d\w\s._-]+)"/));
+  const userDisplayName = getIndexOne(user.match(/displayName"{0,}:\s{0,}"([\d\w\s._-]+)"/));
 
   // e.g. `pubKeyCredParams: [
   // { \"type\": \"public-key\", \"alg\": -257 }, { \"type\": \"public-key\", \"alg\": -7 }
   // ]`
   const pubKeyCredParamsString = getIndexOne(
-    text.match(/pubKeyCredParams:\s{0,}\[([^]+) ]/),
+    text.match(/pubKeyCredParams"{0,}:\s{0,}\[([^]+) ]/),
   ).trim();
   // e.g. `{ \"type\": \"public-key\", \"alg\": -257 }, { \"type\": \"public-key\", \"alg\": -7 }`
   const pubKeyCredParams = parsePubKeyArray(pubKeyCredParamsString);
@@ -46,7 +51,7 @@ function parseWebAuthnRegisterText(text: string): PublicKeyCredentialCreationOpt
 
   // e.g. `challenge: new Int8Array([87, -95, 18, ... -3,  49, 12, 81]).buffer,`
   const challengeArr: string[] = ensureArray(
-    text.match(/challenge:\s{0,}new\s{0,}(Uint|Int)8Array\(([^\)]+)/),
+    text.match(/challenge"{0,}:\s{0,}new\s{0,}(Uint|Int)8Array\(([^\)]+)/),
   );
   // e.g. `[87, -95, 18, ... -3,  49, 12, 81]`
   const challengeJSON = JSON.parse(challengeArr[2]);
@@ -57,12 +62,14 @@ function parseWebAuthnRegisterText(text: string): PublicKeyCredentialCreationOpt
     attestation,
     authenticatorSelection: {
       userVerification,
+      // Only include requireResidentKey prop if the value is of string "true"
+      ...(requireResidentKey === 'true' && { requireResidentKey: !!requireResidentKey }),
     },
     challenge,
     pubKeyCredParams,
     rp: {
       name: rpName,
-      // only add key-value pair if proper value is provided
+      // only add key-value pair if truthy value is provided
       ...(rpId && { id: rpId }),
     },
     timeout,
@@ -81,11 +88,11 @@ function parseWebAuthnAuthenticateText(text: string): PublicKeyCredentialRequest
   // \"id\": new Int8Array([-107, 93, 68, -67, ... -19, 7, 4]).buffer }
   // ]`
   const allowCredentialsText = getIndexOne(
-    text.match(/allowCredentials:\s{0,}\[([^]+)\s{0,}]/),
+    text.match(/allowCredentials"{0,}:\s{0,}\[([^]+)\s{0,}]/),
   ).trim();
   // e.g. `"userVerification":"preferred"`
   const userVerification = getIndexOne(
-    text.match(/"userVerification":\s{0,}"(\w+)"/),
+    text.match(/userVerification"{0,}:\s{0,}"(\w+)"/),
   ) as UserVerificationType;
 
   if (allowCredentialsText) {
@@ -94,9 +101,9 @@ function parseWebAuthnAuthenticateText(text: string): PublicKeyCredentialRequest
     // Iterating over array of substrings
     allowCredentials = allowCredentialArr.map((str) => {
       // e.g. `{ \"type\": \"public-key\",
-      const type = getIndexOne(str.match(/"type":\s{0,}"([\w-]+)"/)) as 'public-key';
+      const type = getIndexOne(str.match(/type"{0,}:\s{0,}"([\w-]+)"/)) as 'public-key';
       // e.g. \"id\": new Int8Array([-107, 93, 68, -67, ... -19, 7, 4]).buffer
-      const idArr = ensureArray(text.match(/"id":\s{0,}new\s{0,}(Uint|Int)8Array\(([^\)]+)/));
+      const idArr = ensureArray(text.match(/id"{0,}:\s{0,}new\s{0,}(Uint|Int)8Array\(([^\)]+)/));
       // e.g. `[-107, 93, 68, -67, ... -19, 7, 4]`
       const idJSON = JSON.parse(idArr[2]);
       // e.g. [-107, 93, 68, -67, ... -19, 7, 4]
@@ -110,23 +117,23 @@ function parseWebAuthnAuthenticateText(text: string): PublicKeyCredentialRequest
   }
 
   // e.g. `timeout: 60000`
-  const timeout = Number(getIndexOne(text.match(/timeout:\s{0,}(\d+)/)));
+  const timeout = Number(getIndexOne(text.match(/timeout"{0,}:\s{0,}(\d+)/)));
 
   // e.g. `challenge: new Int8Array([87, -95, 18, ... -3,  49, 12, 81]).buffer,`
   const challengeArr: string[] = ensureArray(
-    text.match(/challenge:\s{0,}new\s{0,}(Uint|Int)8Array\(([^\)]+)/),
+    text.match(/challenge"{0,}:\s{0,}new\s{0,}(Uint|Int)8Array\(([^\)]+)/),
   );
   // e.g. `[87, -95, 18, ... -3,  49, 12, 81]`
   const challengeJSON = JSON.parse(challengeArr[2]);
   // e.g. [87, -95, 18, ... -3,  49, 12, 81]
   const challenge = new Int8Array(challengeJSON).buffer;
   // e.g. `rpId: \"example.com\"`
-  const rpId = getIndexOne(text.match(/rpId:\s{0,}\\{0,}"([^"\\]*)/));
+  const rpId = getIndexOne(text.match(/rpId"{0,}:\s{0,}\\{0,}"([^"\\]*)/));
 
   return {
     challenge,
     timeout,
-    // only add key-value pairs if the proper value is provided
+    // only add key-value pairs if the truthy values are provided
     ...(allowCredentials && { allowCredentials }),
     ...(userVerification && { userVerification }),
     ...(rpId && { rpId }),

--- a/src/fr-webauthn/script-text.mock.data.ts
+++ b/src/fr-webauthn/script-text.mock.data.ts
@@ -16,7 +16,41 @@ var options = {
    rpId: "example.com",
    challenge: new Int8Array([14, 126, -110, -74, 64, -66, 20, -56, -40, -28, 116, -61, -128, -20, 72, 24, 42, 79, -105, 94, -84, -12, -17, -97, 105, -31, -30, 92, 55, 67, -83, 65]).buffer,
    timeout: 60000,
-   allowCredentials: [{ "type": "public-key", "id": new Int8Array([-107, 93, 68, -67, -5, 107, 18, 16, -25, -30, 80, 103, -75, -53, -2, -95, 102, 42, 47, 126, -1, 85, 93, 45, -85, 8, -108, 107, 47, -25, 66, 12, -96, 81, 104, -127, 26, -59, -69, -23, 75, 89, 58, 124, -93, 4, 28, -128, 121, 35, 39, 103, -86, -86, 123, -67, -7, -4, 79, -49, 127, -19, 7, 4]).buffer }]
+   allowCredentials: [{ type: "public-key", id: new Int8Array([-107, 93, 68, -67, -5, 107, 18, 16, -25, -30, 80, 103, -75, -53, -2, -95, 102, 42, 47, 126, -1, 85, 93, 45, -85, 8, -108, 107, 47, -25, 66, 12, -96, 81, 104, -127, 26, -59, -69, -23, 75, 89, 58, 124, -93, 4, 28, -128, 121, 35, 39, 103, -86, -86, 123, -67, -7, -4, 79, -49, 127, -19, 7, 4]).buffer }]
+};
+
+navigator.credentials.get({ "publicKey" : options })
+   .then(function (assertion) {
+       var clientData = String.fromCharCode.apply(null, new Uint8Array(assertion.response.clientDataJSON));
+       var authenticatorData = new Int8Array(assertion.response.authenticatorData).toString();
+       var signature = new Int8Array(assertion.response.signature).toString();
+       var rawId = assertion.id;
+       var userHandle = String.fromCharCode.apply(null, new Uint8Array(assertion.response.userHandle));
+       document.getElementById('webAuthnOutcome').value = clientData + "::" + authenticatorData + "::" + signature + "::" + rawId + "::" + userHandle;
+       document.getElementById("loginButton_0").click();
+   }).catch(function (err) {
+       document.getElementById('webAuthnOutcome').value = "ERROR" + "::" + err;
+       document.getElementById("loginButton_0").click();
+   });`;
+
+const authenticateInputWithRpidAllowCredentialsAndQuotes = `/*
+* Copyright 2018-2020 ForgeRock AS. All Rights Reserved
+*
+* Use of this code requires a commercial software license with ForgeRock AS.
+* or with one of its affiliates. All use shall be exclusively subject
+* to such license between the licensee and ForgeRock AS.
+*/
+
+if (!window.PublicKeyCredential) {
+   document.getElementById('webAuthnOutcome').value = "unsupported";
+   document.getElementById("loginButton_0").click();
+}
+
+var options = {
+   "rpId": "example.com",
+   "challenge": new Int8Array([14, 126, -110, -74, 64, -66, 20, -56, -40, -28, 116, -61, -128, -20, 72, 24, 42, 79, -105, 94, -84, -12, -17, -97, 105, -31, -30, 92, 55, 67, -83, 65]).buffer,
+   "timeout": 60000,
+   "allowCredentials": [{ "type": "public-key", "id": new Int8Array([-107, 93, 68, -67, -5, 107, 18, 16, -25, -30, 80, 103, -75, -53, -2, -95, 102, 42, 47, 126, -1, 85, 93, 45, -85, 8, -108, 107, 47, -25, 66, 12, -96, 81, 104, -127, 26, -59, -69, -23, 75, 89, 58, 124, -93, 4, 28, -128, 121, 35, 39, 103, -86, -86, 123, -67, -7, -4, 79, -49, 127, -19, 7, 4]).buffer }]
 };
 
 navigator.credentials.get({ "publicKey" : options })
@@ -91,11 +125,13 @@ var publicKey = {
         name: "57a5b4e4-6999-4b45-bf86-a4f2e5d4b629",
         displayName: "Bob Tester"
     },
-    pubKeyCredParams: [ { "type": "public-key", "alg": -257 }, { "type": "public-key", "alg": -7 } ],
+    pubKeyCredParams: [ { type: "public-key", alg: -257 }, { type: "public-key", alg: -7 } ],
     attestation: "none",
     timeout: 60000,
     excludeCredentials: [],
-    authenticatorSelection: {"userVerification":"preferred"}
+    authenticatorSelection: {
+      userVerification: "preferred"
+    }
 };
 
 navigator.credentials.create({publicKey: publicKey})
@@ -109,6 +145,51 @@ navigator.credentials.create({publicKey: publicKey})
         document.getElementById('webAuthnOutcome').value = "ERROR" + "::" + err;
         document.getElementById("loginButton_0").click();
     });`;
+
+const registerInputWithRpidAndQuotes = `/*
+    * Copyright 2018-2020 ForgeRock AS. All Rights Reserved
+    *
+    * Use of this code requires a commercial software license with ForgeRock AS.
+    * or with one of its affiliates. All use shall be exclusively subject
+    * to such license between the licensee and ForgeRock AS.
+    */
+
+   if (!window.PublicKeyCredential) {
+       document.getElementById('webAuthnOutcome').value = "unsupported";
+       document.getElementById("loginButton_0").click();
+   }
+
+   var publicKey = {
+       "challenge": new Int8Array([102, -15, -36, -101, -95, 10, -20, 39, 29, 70, 122, 25, 53, 83, 72, -38, 83, -92, 31, -30, 26, -94, 92, -94, -83, 7, 82, -66, -125, -95, -4, -75]).buffer,
+       // Relying Party:
+       "rp": {
+           "id": "example.com",
+           "name": "ForgeRock"
+       },
+       // User:
+       "user": {
+           "id": Uint8Array.from("NTdhNWI0ZTQtNjk5OS00YjQ1LWJmODYtYTRmMmU1ZDRiNjI5", function (c) { return c.charCodeAt(0) }),
+           "name": "57a5b4e4-6999-4b45-bf86-a4f2e5d4b629",
+           "displayName": "Bob Tester"
+       },
+       "pubKeyCredParams": [ { "type": "public-key", "alg": -257 }, { "type": "public-key", "alg": -7 } ],
+       "attestation": "none",
+       "timeout": 60000,
+       "excludeCredentials": [],
+       "authenticatorSelection": {"userVerification":"preferred"}
+   };
+
+   navigator.credentials.create({publicKey: publicKey})
+       .then(function (newCredentialInfo) {
+           var rawId = newCredentialInfo.id;
+           var clientData = String.fromCharCode.apply(null, new Uint8Array(newCredentialInfo.response.clientDataJSON));
+           var keyData = new Int8Array(newCredentialInfo.response.attestationObject).toString();
+           document.getElementById('webAuthnOutcome').value = clientData + "::" + keyData + "::" + rawId;
+           document.getElementById("loginButton_0").click();
+       }).catch(function (err) {
+           document.getElementById('webAuthnOutcome').value = "ERROR" + "::" + err;
+           document.getElementById("loginButton_0").click();
+       });`;
 
 const registerOutputWithRpid = {
   attestation: 'none',
@@ -198,8 +279,10 @@ const registerOutputWithoutRpid = {
 
 export {
   authenticateInputWithRpidAndAllowCredentials,
+  authenticateInputWithRpidAllowCredentialsAndQuotes,
   authenticateInputWithoutRpidAndAllowCredentials,
   registerInputWithRpid,
+  registerInputWithRpidAndQuotes,
   registerOutputWithRpid,
   registerInputWithoutRpid,
   registerOutputWithoutRpid,


### PR DESCRIPTION
**Summary**:

WebAuthn and AM support the idea of "usernameless" capability with WebAuthn tech that supports the storing of the username with the authentication device. When logging in, the user can use the device alone without the need for username or password input.

**Details**:

- Ensure the property of `requireResidentKey` is passed to the key creation options on both JSON-based and script-based configuration
- Ensure `userHandle` from the credential outcome is passed to the key getter options on both JSON-based and script-based configuration

**Testing**:

To test this, the easiest way is to reuse the `tests/e2e/app/authn-webauthn` test page and `PasswordlessWebAuthn` (if not, you'll have to build two different trees):

1. Ensure `PasswordlessWebAuthn` tree is built similar to the picture in the `authn-webauthn` directory
2. In this tree, modify _only_ the WebAuthn registration node to store username on device
3. Now, in Chrome on Mac, run the WebAuthn test script, but stop at the device registration prompt
4. Return to the tree in AM , and update the authentication node to use username from device
5. Complete the device registration using the fingerprint reader
6. The registration should be successful
7. It will then logout and re-authenticate, triggering the WebAuthn request with username from the device
8. Use the same method, but you should now have to choose the user account
9. You should successfully authenticate and logout
10. Test script complete

**Screen recording**:

![usernameless-login](https://user-images.githubusercontent.com/3070458/88597471-dfcb4300-d02c-11ea-98c1-2a75476394a8.gif)
