### PR TITLE
Fix (oauth): improve the entropy of oauth; deprecate nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@
 
 - Conditionally set user verification, relying party and allow credentials to WebAuthn key options
 - Ensure display name and username are correctly parsed and added to WebAuthn key options
+- Add authenticator attachment to WebAuthn and other WebAuthn fixes for custom configuration
+- Increased entropy for cryptographic functions related to PKCE for both state and verifier
+- Improved instructions for cert creation for sample app
+
+### Deprecated
+
+- Name change for `getAuthorizeUrl`: method's name will change to better reflect its behavior in v3
+- Removal of `nonce`: this utility is no longer used in the SDK, and therefor will be removed in v3
+- Function signature change for `createVerifier`: the parameter will be removed in v3.
 
 ## [2.0.0] - 2020-06-22
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,19 +14,19 @@
       }
     },
     "@babel/core": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
-      "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
+      "integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.10.5",
-        "@babel/helper-module-transforms": "^7.10.5",
+        "@babel/generator": "^7.11.0",
+        "@babel/helper-module-transforms": "^7.11.0",
         "@babel/helpers": "^7.10.4",
-        "@babel/parser": "^7.10.5",
+        "@babel/parser": "^7.11.1",
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.5",
-        "@babel/types": "^7.10.5",
+        "@babel/traverse": "^7.11.0",
+        "@babel/types": "^7.11.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -55,12 +55,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-      "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
+      "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.5",
+        "@babel/types": "^7.11.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -86,12 +86,12 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
-      "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+      "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.5"
+        "@babel/types": "^7.11.0"
       }
     },
     "@babel/helper-module-imports": {
@@ -104,17 +104,17 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
-      "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+      "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
         "@babel/helper-replace-supers": "^7.10.4",
         "@babel/helper-simple-access": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
         "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.5",
+        "@babel/types": "^7.11.0",
         "lodash": "^4.17.19"
       }
     },
@@ -156,12 +156,12 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-      "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.11.0"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -245,9 +245,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-      "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.2.tgz",
+      "integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -361,17 +361,17 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-      "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+      "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.10.5",
+        "@babel/generator": "^7.11.0",
         "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.10.4",
-        "@babel/parser": "^7.10.5",
-        "@babel/types": "^7.10.5",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/parser": "^7.11.0",
+        "@babel/types": "^7.11.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
@@ -386,9 +386,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-      "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+      "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
@@ -469,26 +469,28 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.1.0.tgz",
-      "integrity": "sha512-+0lpTHMd/8pJp+Nd4lyip+/Iyf2dZJvcCqrlkeZQoQid+JlThA4M9vxHtheyrQ99jJTMQam+es4BcvZ5W5cC3A==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.2.0.tgz",
+      "integrity": "sha512-mXQfx3nSLwiHm1i7jbu+uvi+vvpVjNGzIQYLCfsat9rapC+MJkS4zBseNrgJE0vU921b3P67bQzhduphjY3Tig==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
+        "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^26.1.0",
-        "jest-util": "^26.1.0",
+        "jest-message-util": "^26.2.0",
+        "jest-util": "^26.2.0",
         "slash": "^3.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -512,33 +514,34 @@
       }
     },
     "@jest/core": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.1.0.tgz",
-      "integrity": "sha512-zyizYmDJOOVke4OO/De//aiv8b07OwZzL2cfsvWF3q9YssfpcKfcnZAwDY8f+A76xXSMMYe8i/f/LPocLlByfw==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.2.2.tgz",
+      "integrity": "sha512-UwA8gNI8aeV4FHGfGAUfO/DHjrFVvlBravF1Tm9Kt6qFE+6YHR47kFhgdepOFpADEKstyO+MVdPvkV6/dyt9sA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.1.0",
-        "@jest/reporters": "^26.1.0",
-        "@jest/test-result": "^26.1.0",
-        "@jest/transform": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/console": "^26.2.0",
+        "@jest/reporters": "^26.2.2",
+        "@jest/test-result": "^26.2.0",
+        "@jest/transform": "^26.2.2",
+        "@jest/types": "^26.2.0",
+        "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^26.1.0",
-        "jest-config": "^26.1.0",
-        "jest-haste-map": "^26.1.0",
-        "jest-message-util": "^26.1.0",
+        "jest-changed-files": "^26.2.0",
+        "jest-config": "^26.2.2",
+        "jest-haste-map": "^26.2.2",
+        "jest-message-util": "^26.2.0",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.1.0",
-        "jest-resolve-dependencies": "^26.1.0",
-        "jest-runner": "^26.1.0",
-        "jest-runtime": "^26.1.0",
-        "jest-snapshot": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "jest-validate": "^26.1.0",
-        "jest-watcher": "^26.1.0",
+        "jest-resolve": "^26.2.2",
+        "jest-resolve-dependencies": "^26.2.2",
+        "jest-runner": "^26.2.2",
+        "jest-runtime": "^26.2.2",
+        "jest-snapshot": "^26.2.2",
+        "jest-util": "^26.2.0",
+        "jest-validate": "^26.2.0",
+        "jest-watcher": "^26.2.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
@@ -547,13 +550,14 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -629,24 +633,26 @@
       }
     },
     "@jest/environment": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.1.0.tgz",
-      "integrity": "sha512-86+DNcGongbX7ai/KE/S3/NcUVZfrwvFzOOWX/W+OOTvTds7j07LtC+MgGydH5c8Ri3uIrvdmVgd1xFD5zt/xA==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.2.0.tgz",
+      "integrity": "sha512-oCgp9NmEiJ5rbq9VI/v/yYLDpladAAVvFxZgNsnJxOETuzPZ0ZcKKHYjKYwCtPOP1WCrM5nmyuOhMStXFGHn+g==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^26.1.0",
-        "@jest/types": "^26.1.0",
-        "jest-mock": "^26.1.0"
+        "@jest/fake-timers": "^26.2.0",
+        "@jest/types": "^26.2.0",
+        "@types/node": "*",
+        "jest-mock": "^26.2.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -664,26 +670,28 @@
       }
     },
     "@jest/fake-timers": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.1.0.tgz",
-      "integrity": "sha512-Y5F3kBVWxhau3TJ825iuWy++BAuQzK/xEa+wD9vDH3RytW9f2DbMVodfUQC54rZDX3POqdxCgcKdgcOL0rYUpA==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.2.0.tgz",
+      "integrity": "sha512-45Gfe7YzYTKqTayBrEdAF0qYyAsNRBzfkV0IyVUm3cx7AsCWlnjilBM4T40w7IXT5VspOgMPikQlV0M6gHwy/g==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
         "@sinonjs/fake-timers": "^6.0.1",
-        "jest-message-util": "^26.1.0",
-        "jest-mock": "^26.1.0",
-        "jest-util": "^26.1.0"
+        "@types/node": "*",
+        "jest-message-util": "^26.2.0",
+        "jest-mock": "^26.2.0",
+        "jest-util": "^26.2.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -701,24 +709,25 @@
       }
     },
     "@jest/globals": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.1.0.tgz",
-      "integrity": "sha512-MKiHPNaT+ZoG85oMaYUmGHEqu98y3WO2yeIDJrs2sJqHhYOy3Z6F7F/luzFomRQ8SQ1wEkmahFAz2291Iv8EAw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.2.0.tgz",
+      "integrity": "sha512-Hoc6ScEIPaym7RNytIL2ILSUWIGKlwEv+JNFof9dGYOdvPjb2evEURSslvCMkNuNg1ECEClTE8PH7ULlMJntYA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.1.0",
-        "@jest/types": "^26.1.0",
-        "expect": "^26.1.0"
+        "@jest/environment": "^26.2.0",
+        "@jest/types": "^26.2.0",
+        "expect": "^26.2.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -736,16 +745,16 @@
       }
     },
     "@jest/reporters": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.1.0.tgz",
-      "integrity": "sha512-SVAysur9FOIojJbF4wLP0TybmqwDkdnFxHSPzHMMIYyBtldCW9gG+Q5xWjpMFyErDiwlRuPyMSJSU64A67Pazg==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.2.2.tgz",
+      "integrity": "sha512-7854GPbdFTAorWVh+RNHyPO9waRIN6TcvCezKVxI1khvFq9YjINTW7J3WU+tbR038Ynn6WjYred6vtT0YmIWVQ==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^26.1.0",
-        "@jest/test-result": "^26.1.0",
-        "@jest/transform": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/console": "^26.2.0",
+        "@jest/test-result": "^26.2.0",
+        "@jest/transform": "^26.2.2",
+        "@jest/types": "^26.2.0",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -756,10 +765,10 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^26.1.0",
-        "jest-resolve": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "jest-worker": "^26.1.0",
+        "jest-haste-map": "^26.2.2",
+        "jest-resolve": "^26.2.2",
+        "jest-util": "^26.2.0",
+        "jest-worker": "^26.2.1",
         "node-notifier": "^7.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
@@ -769,13 +778,14 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -824,25 +834,26 @@
       }
     },
     "@jest/test-result": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.1.0.tgz",
-      "integrity": "sha512-Xz44mhXph93EYMA8aYDz+75mFbarTV/d/x0yMdI3tfSRs/vh4CqSxgzVmCps1fPkHDCtn0tU8IH9iCKgGeGpfw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.2.0.tgz",
+      "integrity": "sha512-kgPlmcVafpmfyQEu36HClK+CWI6wIaAWDHNxfQtGuKsgoa2uQAYdlxjMDBEa3CvI40+2U3v36gQF6oZBkoKatw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/console": "^26.2.0",
+        "@jest/types": "^26.2.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -860,34 +871,34 @@
       }
     },
     "@jest/test-sequencer": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.1.0.tgz",
-      "integrity": "sha512-Z/hcK+rTq56E6sBwMoQhSRDVjqrGtj1y14e2bIgcowARaIE1SgOanwx6gvY4Q9gTKMoZQXbXvptji+q5GYxa6Q==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.2.2.tgz",
+      "integrity": "sha512-SliZWon5LNqV/lVXkeowSU6L8++FGOu3f43T01L1Gv6wnFDP00ER0utV9jyK9dVNdXqfMNCN66sfcyar/o7BNw==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.1.0",
+        "@jest/test-result": "^26.2.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.1.0",
-        "jest-runner": "^26.1.0",
-        "jest-runtime": "^26.1.0"
+        "jest-haste-map": "^26.2.2",
+        "jest-runner": "^26.2.2",
+        "jest-runtime": "^26.2.2"
       }
     },
     "@jest/transform": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.1.0.tgz",
-      "integrity": "sha512-ICPm6sUXmZJieq45ix28k0s+d/z2E8CHDsq+WwtWI6kW8m7I8kPqarSEcUN86entHQ570ZBRci5OWaKL0wlAWw==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.2.2.tgz",
+      "integrity": "sha512-c1snhvi5wRVre1XyoO3Eef5SEWpuBCH/cEbntBUd9tI5sNYiBDmO0My/lc5IuuGYKp/HFIHV1eZpSx5yjdkhKw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.1.0",
+        "jest-haste-map": "^26.2.2",
         "jest-regex-util": "^26.0.0",
-        "jest-util": "^26.1.0",
+        "jest-util": "^26.2.0",
         "micromatch": "^4.0.2",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -896,13 +907,14 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -1161,9 +1173,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.26.tgz",
-      "integrity": "sha512-W+fpe5s91FBGE0pEa0lnqGLL4USgpLgs4nokw16SrBBco/gQxuua7KnArSEOd5iaMqbbSHV10vUDkJYJJqpXKA==",
+      "version": "14.0.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1470,9 +1482,9 @@
       }
     },
     "acorn": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
       "dev": true
     },
     "acorn-globals": {
@@ -1858,29 +1870,30 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.1.0.tgz",
-      "integrity": "sha512-Nkqgtfe7j6PxLO6TnCQQlkMm8wdTdnIF8xrdpooHCuD5hXRzVEPbPneTJKknH5Dsv3L8ip9unHDAp48YQ54Dkg==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.2.2.tgz",
+      "integrity": "sha512-JmLuePHgA+DSOdOL8lPxCgD2LhPPm+rdw1vnxR73PpIrnmKCS2/aBhtkAcxQWuUcW2hBrH8MJ3LKXE7aWpNZyA==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/transform": "^26.2.2",
+        "@jest/types": "^26.2.0",
         "@types/babel__core": "^7.1.7",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^26.1.0",
+        "babel-preset-jest": "^26.2.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -1917,9 +1930,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.1.0.tgz",
-      "integrity": "sha512-qhqLVkkSlqmC83bdMhM8WW4Z9tB+JkjqAqlbbohS9sJLT5Ha2vfzuKqg5yenXrAjOPG2YC0WiXdH3a9PvB+YYw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
+      "integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -1948,12 +1961,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.1.0.tgz",
-      "integrity": "sha512-na9qCqFksknlEj5iSdw1ehMVR06LCCTkZLGKeEtxDDdhg8xpUF09m29Kvh1pRbZ07h7AQ5ttLYUwpXL4tO6w7w==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.2.0.tgz",
+      "integrity": "sha512-R1k8kdP3R9phYQugXeNnK/nvCGlBzG4m3EoIIukC80GXb6wCv2XiwPhK6K9MAkQcMszWBYvl2Wm+yigyXFQqXg==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^26.1.0",
+        "babel-plugin-jest-hoist": "^26.2.0",
         "babel-preset-current-node-syntax": "^0.1.2"
       }
     },
@@ -2426,9 +2439,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
-      "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3302,6 +3315,12 @@
         }
       }
     },
+    "emittery": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
+      "integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3509,9 +3528,9 @@
       }
     },
     "eslint": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.5.0.tgz",
-      "integrity": "sha512-vlUP10xse9sWt9SGRtcr1LAC67BENcQMFeV+w5EvLEoFe3xJ8cF1Skd0msziRx/VMC+72B4DxreCE+OR12OA6Q==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.6.0.tgz",
+      "integrity": "sha512-QlAManNtqr7sozWm5TF4wIH9gmUm2hE3vNRUvyoYAa4y1l5/jxD/PQStEjBMQtCqZmSep8UxrcecI60hOpe61w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -3837,27 +3856,28 @@
       }
     },
     "expect": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-26.1.0.tgz",
-      "integrity": "sha512-QbH4LZXDsno9AACrN9eM0zfnby9G+OsdNgZUohjg/P0mLy1O+/bzTAJGT6VSIjVCe8yKM6SzEl/ckEOFBT7Vnw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-26.2.0.tgz",
+      "integrity": "sha512-8AMBQ9UVcoUXt0B7v+5/U5H6yiUR87L6eKCfjE3spx7Ya5lF+ebUo37MCFBML2OiLfkX1sxmQOZhIDonyVTkcw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
         "ansi-styles": "^4.0.0",
         "jest-get-type": "^26.0.0",
-        "jest-matcher-utils": "^26.1.0",
-        "jest-message-util": "^26.1.0",
+        "jest-matcher-utils": "^26.2.0",
+        "jest-message-util": "^26.2.0",
         "jest-regex-util": "^26.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -4839,12 +4859,12 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       }
     },
@@ -5440,9 +5460,9 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
@@ -5588,24 +5608,25 @@
       }
     },
     "jest": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-26.1.0.tgz",
-      "integrity": "sha512-LIti8jppw5BcQvmNJe4w2g1N/3V68HUfAv9zDVm7v+VAtQulGhH0LnmmiVkbNE4M4I43Bj2fXPiBGKt26k9tHw==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-26.2.2.tgz",
+      "integrity": "sha512-EkJNyHiAG1+A8pqSz7cXttoVa34hOEzN/MrnJhYnfp5VHxflVcf2pu3oJSrhiy6LfIutLdWo+n6q63tjcoIeig==",
       "dev": true,
       "requires": {
-        "@jest/core": "^26.1.0",
+        "@jest/core": "^26.2.2",
         "import-local": "^3.0.2",
-        "jest-cli": "^26.1.0"
+        "jest-cli": "^26.2.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -5621,22 +5642,22 @@
           }
         },
         "jest-cli": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.1.0.tgz",
-          "integrity": "sha512-Imumvjgi3rU7stq6SJ1JUEMaV5aAgJYXIs0jPqdUnF47N/Tk83EXfmtvNKQ+SnFVI6t6mDOvfM3aA9Sg6kQPSw==",
+          "version": "26.2.2",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.2.2.tgz",
+          "integrity": "sha512-vVcly0n/ijZvdy6gPQiQt0YANwX2hLTPQZHtW7Vi3gcFdKTtif7YpI85F8R8JYy5DFSWz4x1OW0arnxlziu5Lw==",
           "dev": true,
           "requires": {
-            "@jest/core": "^26.1.0",
-            "@jest/test-result": "^26.1.0",
-            "@jest/types": "^26.1.0",
+            "@jest/core": "^26.2.2",
+            "@jest/test-result": "^26.2.0",
+            "@jest/types": "^26.2.0",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
             "is-ci": "^2.0.0",
-            "jest-config": "^26.1.0",
-            "jest-util": "^26.1.0",
-            "jest-validate": "^26.1.0",
+            "jest-config": "^26.2.2",
+            "jest-util": "^26.2.0",
+            "jest-validate": "^26.2.0",
             "prompts": "^2.0.1",
             "yargs": "^15.3.1"
           }
@@ -5654,24 +5675,25 @@
       }
     },
     "jest-changed-files": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.1.0.tgz",
-      "integrity": "sha512-HS5MIJp3B8t0NRKGMCZkcDUZo36mVRvrDETl81aqljT1S9tqiHRSpyoOvWg9ZilzZG9TDisDNaN1IXm54fLRZw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.2.0.tgz",
+      "integrity": "sha512-+RyJb+F1K/XBLIYiL449vo5D+CvlHv29QveJUWNPXuUicyZcq+tf1wNxmmFeRvAU1+TzhwqczSjxnCCFt7+8iA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
         "execa": "^4.0.0",
         "throat": "^5.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -5730,39 +5752,40 @@
       }
     },
     "jest-config": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.1.0.tgz",
-      "integrity": "sha512-ONTGeoMbAwGCdq4WuKkMcdMoyfs5CLzHEkzFOlVvcDXufZSaIWh/OXMLa2fwKXiOaFcqEw8qFr4VOKJQfn4CVw==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.2.2.tgz",
+      "integrity": "sha512-2lhxH0y4YFOijMJ65usuf78m7+9/8+hAb1PZQtdRdgnQpAb4zP6KcVDDktpHEkspBKnc2lmFu+RQdHukUUbiTg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^26.1.0",
-        "@jest/types": "^26.1.0",
-        "babel-jest": "^26.1.0",
+        "@jest/test-sequencer": "^26.2.2",
+        "@jest/types": "^26.2.0",
+        "babel-jest": "^26.2.2",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
-        "jest-environment-jsdom": "^26.1.0",
-        "jest-environment-node": "^26.1.0",
+        "jest-environment-jsdom": "^26.2.0",
+        "jest-environment-node": "^26.2.0",
         "jest-get-type": "^26.0.0",
-        "jest-jasmine2": "^26.1.0",
+        "jest-jasmine2": "^26.2.2",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "jest-validate": "^26.1.0",
+        "jest-resolve": "^26.2.2",
+        "jest-util": "^26.2.0",
+        "jest-validate": "^26.2.0",
         "micromatch": "^4.0.2",
-        "pretty-format": "^26.1.0"
+        "pretty-format": "^26.2.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -5818,12 +5841,12 @@
           }
         },
         "pretty-format": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",
-          "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+          "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.1.0",
+            "@jest/types": "^26.2.0",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -5877,26 +5900,27 @@
       }
     },
     "jest-each": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.1.0.tgz",
-      "integrity": "sha512-lYiSo4Igr81q6QRsVQq9LIkJW0hZcKxkIkHzNeTMPENYYDw/W/Raq28iJ0sLlNFYz2qxxeLnc5K2gQoFYlu2bA==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.2.0.tgz",
+      "integrity": "sha512-gHPCaho1twWHB5bpcfnozlc6mrMi+VAewVPNgmwf81x2Gzr6XO4dl+eOrwPWxbkYlgjgrYjWK2xgKnixbzH3Ew==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^26.0.0",
-        "jest-util": "^26.1.0",
-        "pretty-format": "^26.1.0"
+        "jest-util": "^26.2.0",
+        "pretty-format": "^26.2.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -5918,12 +5942,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",
-          "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+          "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.1.0",
+            "@jest/types": "^26.2.0",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -5932,27 +5956,29 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.1.0.tgz",
-      "integrity": "sha512-dWfiJ+spunVAwzXbdVqPH1LbuJW/kDL+FyqgA5YzquisHqTi0g9hquKif9xKm7c1bKBj6wbmJuDkeMCnxZEpUw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.2.0.tgz",
+      "integrity": "sha512-sDG24+5M4NuIGzkI3rJW8XUlrpkvIdE9Zz4jhD8OBnVxAw+Y1jUk9X+lAOD48nlfUTlnt3lbAI3k2Ox+WF3S0g==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.1.0",
-        "@jest/fake-timers": "^26.1.0",
-        "@jest/types": "^26.1.0",
-        "jest-mock": "^26.1.0",
-        "jest-util": "^26.1.0",
+        "@jest/environment": "^26.2.0",
+        "@jest/fake-timers": "^26.2.0",
+        "@jest/types": "^26.2.0",
+        "@types/node": "*",
+        "jest-mock": "^26.2.0",
+        "jest-util": "^26.2.0",
         "jsdom": "^16.2.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -5970,26 +5996,28 @@
       }
     },
     "jest-environment-node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.1.0.tgz",
-      "integrity": "sha512-DNm5x1aQH0iRAe9UYAkZenuzuJ69VKzDCAYISFHQ5i9e+2Tbeu2ONGY7YStubCLH8a1wdKBgqScYw85+ySxqxg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.2.0.tgz",
+      "integrity": "sha512-4M5ExTYkJ19efBzkiXtBi74JqKLDciEk4CEsp5tTjWGYMrlKFQFtwIVG3tW1OGE0AlXhZjuHPwubuRYY4j4uOw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.1.0",
-        "@jest/fake-timers": "^26.1.0",
-        "@jest/types": "^26.1.0",
-        "jest-mock": "^26.1.0",
-        "jest-util": "^26.1.0"
+        "@jest/environment": "^26.2.0",
+        "@jest/fake-timers": "^26.2.0",
+        "@jest/types": "^26.2.0",
+        "@types/node": "*",
+        "jest-mock": "^26.2.0",
+        "jest-util": "^26.2.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6013,34 +6041,36 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.1.0.tgz",
-      "integrity": "sha512-WeBS54xCIz9twzkEdm6+vJBXgRBQfdbbXD0dk8lJh7gLihopABlJmIQFdWSDDtuDe4PRiObsjZSUjbJ1uhWEpA==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.2.2.tgz",
+      "integrity": "sha512-3sJlMSt+NHnzCB+0KhJ1Ut4zKJBiJOlbrqEYNdRQGlXTv8kqzZWjUKQRY3pkjmlf+7rYjAV++MQ4D6g4DhAyOg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
         "@types/graceful-fs": "^4.1.2",
+        "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-serializer": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "jest-worker": "^26.1.0",
+        "jest-regex-util": "^26.0.0",
+        "jest-serializer": "^26.2.0",
+        "jest-util": "^26.2.0",
+        "jest-worker": "^26.2.1",
         "micromatch": "^4.0.2",
         "sane": "^4.0.3",
-        "walker": "^1.0.7",
-        "which": "^2.0.2"
+        "walker": "^1.0.7"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6101,38 +6131,40 @@
       }
     },
     "jest-jasmine2": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.1.0.tgz",
-      "integrity": "sha512-1IPtoDKOAG+MeBrKvvuxxGPJb35MTTRSDglNdWWCndCB3TIVzbLThRBkwH9P081vXLgiJHZY8Bz3yzFS803xqQ==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.2.2.tgz",
+      "integrity": "sha512-Q8AAHpbiZMVMy4Hz9j1j1bg2yUmPa1W9StBvcHqRaKa9PHaDUMwds8LwaDyzP/2fkybcTQE4+pTMDOG9826tEw==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^26.1.0",
+        "@jest/environment": "^26.2.0",
         "@jest/source-map": "^26.1.0",
-        "@jest/test-result": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/test-result": "^26.2.0",
+        "@jest/types": "^26.2.0",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^26.1.0",
+        "expect": "^26.2.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^26.1.0",
-        "jest-matcher-utils": "^26.1.0",
-        "jest-message-util": "^26.1.0",
-        "jest-runtime": "^26.1.0",
-        "jest-snapshot": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "pretty-format": "^26.1.0",
+        "jest-each": "^26.2.0",
+        "jest-matcher-utils": "^26.2.0",
+        "jest-message-util": "^26.2.0",
+        "jest-runtime": "^26.2.2",
+        "jest-snapshot": "^26.2.2",
+        "jest-util": "^26.2.0",
+        "pretty-format": "^26.2.0",
         "throat": "^5.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6148,12 +6180,12 @@
           }
         },
         "pretty-format": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",
-          "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+          "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.1.0",
+            "@jest/types": "^26.2.0",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -6162,23 +6194,24 @@
       }
     },
     "jest-leak-detector": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.1.0.tgz",
-      "integrity": "sha512-dsMnKF+4BVOZwvQDlgn3MG+Ns4JuLv8jNvXH56bgqrrboyCbI1rQg6EI5rs+8IYagVcfVP2yZFKfWNZy0rK0Hw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.2.0.tgz",
+      "integrity": "sha512-aQdzTX1YiufkXA1teXZu5xXOJgy7wZQw6OJ0iH5CtQlOETe6gTSocaYKUNui1SzQ91xmqEUZ/WRavg9FD82rtQ==",
       "dev": true,
       "requires": {
         "jest-get-type": "^26.0.0",
-        "pretty-format": "^26.1.0"
+        "pretty-format": "^26.2.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6200,12 +6233,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",
-          "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+          "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.1.0",
+            "@jest/types": "^26.2.0",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -6214,25 +6247,26 @@
       }
     },
     "jest-matcher-utils": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.1.0.tgz",
-      "integrity": "sha512-PW9JtItbYvES/xLn5mYxjMd+Rk+/kIt88EfH3N7w9KeOrHWaHrdYPnVHndGbsFGRJ2d5gKtwggCvkqbFDoouQA==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.2.0.tgz",
+      "integrity": "sha512-2cf/LW2VFb3ayPHrH36ZDjp9+CAeAe/pWBAwsV8t3dKcrINzXPVxq8qMWOxwt5BaeBCx4ZupVGH7VIgB8v66vQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^26.1.0",
+        "jest-diff": "^26.2.0",
         "jest-get-type": "^26.0.0",
-        "pretty-format": "^26.1.0"
+        "pretty-format": "^26.2.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6254,15 +6288,15 @@
           "dev": true
         },
         "jest-diff": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.1.0.tgz",
-          "integrity": "sha512-GZpIcom339y0OXznsEKjtkfKxNdg7bVbEofK8Q6MnevTIiR1jNhDWKhRX6X0SDXJlwn3dy59nZ1z55fLkAqPWg==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.2.0.tgz",
+          "integrity": "sha512-Wu4Aopi2nzCsHWLBlD48TgRy3Z7OsxlwvHNd1YSnHc7q1NJfrmyCPoUXrTIrydQOG5ApaYpsAsdfnMbJqV1/wQ==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
             "diff-sequences": "^26.0.0",
             "jest-get-type": "^26.0.0",
-            "pretty-format": "^26.1.0"
+            "pretty-format": "^26.2.0"
           }
         },
         "jest-get-type": {
@@ -6272,12 +6306,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",
-          "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+          "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.1.0",
+            "@jest/types": "^26.2.0",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -6286,13 +6320,13 @@
       }
     },
     "jest-message-util": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.1.0.tgz",
-      "integrity": "sha512-dY0+UlldiAJwNDJ08SF0HdF32g9PkbF2NRK/+2iMPU40O6q+iSn1lgog/u0UH8ksWoPv0+gNq8cjhYO2MFtT0g==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.2.0.tgz",
+      "integrity": "sha512-g362RhZaJuqeqG108n1sthz5vNpzTNy926eNDszo4ncRbmmcMRIUAZibnd6s5v2XSBCChAxQtCoN25gnzp7JbQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
         "@types/stack-utils": "^1.0.1",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -6302,13 +6336,14 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6375,22 +6410,24 @@
       }
     },
     "jest-mock": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.1.0.tgz",
-      "integrity": "sha512-1Rm8EIJ3ZFA8yCIie92UbxZWj9SuVmUGcyhLHyAhY6WI3NIct38nVcfOPWhJteqSn8V8e3xOMha9Ojfazfpovw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.2.0.tgz",
+      "integrity": "sha512-XeC7yWtWmWByoyVOHSsE7NYsbXJLtJNgmhD7z4MKumKm6ET0si81bsSLbQ64L5saK3TgsHo2B/UqG5KNZ1Sp/Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0"
+        "@jest/types": "^26.2.0",
+        "@types/node": "*"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6420,29 +6457,30 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.1.0.tgz",
-      "integrity": "sha512-KsY1JV9FeVgEmwIISbZZN83RNGJ1CC+XUCikf/ZWJBX/tO4a4NvA21YixokhdR9UnmPKKAC4LafVixJBrwlmfg==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.2.2.tgz",
+      "integrity": "sha512-ye9Tj/ILn/0OgFPE/3dGpQPUqt4dHwIocxt5qSBkyzxQD8PbL0bVxBogX2FHxsd3zJA7V2H/cHXnBnNyyT9YoQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-pnp-resolver": "^1.2.1",
-        "jest-util": "^26.1.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^26.2.0",
         "read-pkg-up": "^7.0.1",
         "resolve": "^1.17.0",
         "slash": "^3.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6466,24 +6504,25 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.1.0.tgz",
-      "integrity": "sha512-fQVEPHHQ1JjHRDxzlLU/buuQ9om+hqW6Vo928aa4b4yvq4ZHBtRSDsLdKQLuCqn5CkTVpYZ7ARh2fbA8WkRE6g==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.2.2.tgz",
+      "integrity": "sha512-S5vufDmVbQXnpP7435gr710xeBGUFcKNpNswke7RmFvDQtmqPjPVU/rCeMlEU0p6vfpnjhwMYeaVjKZAy5QYJA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
         "jest-regex-util": "^26.0.0",
-        "jest-snapshot": "^26.1.0"
+        "jest-snapshot": "^26.2.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6501,40 +6540,42 @@
       }
     },
     "jest-runner": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.1.0.tgz",
-      "integrity": "sha512-elvP7y0fVDREnfqit0zAxiXkDRSw6dgCkzPCf1XvIMnSDZ8yogmSKJf192dpOgnUVykmQXwYYJnCx641uLTgcw==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.2.2.tgz",
+      "integrity": "sha512-/qb6ptgX+KQ+aNMohJf1We695kaAfuu3u3ouh66TWfhTpLd9WbqcF6163d/tMoEY8GqPztXPLuyG0rHRVDLxCA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.1.0",
-        "@jest/environment": "^26.1.0",
-        "@jest/test-result": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/console": "^26.2.0",
+        "@jest/environment": "^26.2.0",
+        "@jest/test-result": "^26.2.0",
+        "@jest/types": "^26.2.0",
+        "@types/node": "*",
         "chalk": "^4.0.0",
+        "emittery": "^0.7.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.1.0",
+        "jest-config": "^26.2.2",
         "jest-docblock": "^26.0.0",
-        "jest-haste-map": "^26.1.0",
-        "jest-jasmine2": "^26.1.0",
-        "jest-leak-detector": "^26.1.0",
-        "jest-message-util": "^26.1.0",
-        "jest-resolve": "^26.1.0",
-        "jest-runtime": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "jest-worker": "^26.1.0",
+        "jest-haste-map": "^26.2.2",
+        "jest-leak-detector": "^26.2.0",
+        "jest-message-util": "^26.2.0",
+        "jest-resolve": "^26.2.2",
+        "jest-runtime": "^26.2.2",
+        "jest-util": "^26.2.0",
+        "jest-worker": "^26.2.1",
         "source-map-support": "^0.5.6",
         "throat": "^5.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6552,47 +6593,48 @@
       }
     },
     "jest-runtime": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.1.0.tgz",
-      "integrity": "sha512-1qiYN+EZLmG1QV2wdEBRf+Ci8i3VSfIYLF02U18PiUDrMbhfpN/EAMMkJtT02jgJUoaEOpHAIXG6zS3QRMzRmA==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.2.2.tgz",
+      "integrity": "sha512-a8VXM3DxCDnCIdl9+QucWFfQ28KdqmyVFqeKLigHdErtsx56O2ZIdQkhFSuP1XtVrG9nTNHbKxjh5XL1UaFDVQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.1.0",
-        "@jest/environment": "^26.1.0",
-        "@jest/fake-timers": "^26.1.0",
-        "@jest/globals": "^26.1.0",
+        "@jest/console": "^26.2.0",
+        "@jest/environment": "^26.2.0",
+        "@jest/fake-timers": "^26.2.0",
+        "@jest/globals": "^26.2.0",
         "@jest/source-map": "^26.1.0",
-        "@jest/test-result": "^26.1.0",
-        "@jest/transform": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/test-result": "^26.2.0",
+        "@jest/transform": "^26.2.2",
+        "@jest/types": "^26.2.0",
         "@types/yargs": "^15.0.0",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.1.0",
-        "jest-haste-map": "^26.1.0",
-        "jest-message-util": "^26.1.0",
-        "jest-mock": "^26.1.0",
+        "jest-config": "^26.2.2",
+        "jest-haste-map": "^26.2.2",
+        "jest-message-util": "^26.2.0",
+        "jest-mock": "^26.2.0",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.1.0",
-        "jest-snapshot": "^26.1.0",
-        "jest-util": "^26.1.0",
-        "jest-validate": "^26.1.0",
+        "jest-resolve": "^26.2.2",
+        "jest-snapshot": "^26.2.2",
+        "jest-util": "^26.2.0",
+        "jest-validate": "^26.2.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^15.3.1"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6616,45 +6658,47 @@
       }
     },
     "jest-serializer": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.1.0.tgz",
-      "integrity": "sha512-eqZOQG/0+MHmr25b2Z86g7+Kzd5dG9dhCiUoyUNJPgiqi38DqbDEOlHcNijyfZoj74soGBohKBZuJFS18YTJ5w==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.2.0.tgz",
+      "integrity": "sha512-V7snZI9IVmyJEu0Qy0inmuXgnMWDtrsbV2p9CRAcmlmPVwpC2ZM8wXyYpiugDQnwLHx0V4+Pnog9Exb3UO8M6Q==",
       "dev": true,
       "requires": {
+        "@types/node": "*",
         "graceful-fs": "^4.2.4"
       }
     },
     "jest-snapshot": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.1.0.tgz",
-      "integrity": "sha512-YhSbU7eMTVQO/iRbNs8j0mKRxGp4plo7sJ3GzOQ0IYjvsBiwg0T1o0zGQAYepza7lYHuPTrG5J2yDd0CE2YxSw==",
+      "version": "26.2.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.2.2.tgz",
+      "integrity": "sha512-NdjD8aJS7ePu268Wy/n/aR1TUisG0BOY+QOW4f6h46UHEKOgYmmkvJhh2BqdVZQ0BHSxTMt04WpCf9njzx8KtA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
         "@types/prettier": "^2.0.0",
         "chalk": "^4.0.0",
-        "expect": "^26.1.0",
+        "expect": "^26.2.0",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^26.1.0",
+        "jest-diff": "^26.2.0",
         "jest-get-type": "^26.0.0",
-        "jest-haste-map": "^26.1.0",
-        "jest-matcher-utils": "^26.1.0",
-        "jest-message-util": "^26.1.0",
-        "jest-resolve": "^26.1.0",
+        "jest-haste-map": "^26.2.2",
+        "jest-matcher-utils": "^26.2.0",
+        "jest-message-util": "^26.2.0",
+        "jest-resolve": "^26.2.2",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^26.1.0",
+        "pretty-format": "^26.2.0",
         "semver": "^7.3.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6676,15 +6720,15 @@
           "dev": true
         },
         "jest-diff": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.1.0.tgz",
-          "integrity": "sha512-GZpIcom339y0OXznsEKjtkfKxNdg7bVbEofK8Q6MnevTIiR1jNhDWKhRX6X0SDXJlwn3dy59nZ1z55fLkAqPWg==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.2.0.tgz",
+          "integrity": "sha512-Wu4Aopi2nzCsHWLBlD48TgRy3Z7OsxlwvHNd1YSnHc7q1NJfrmyCPoUXrTIrydQOG5ApaYpsAsdfnMbJqV1/wQ==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
             "diff-sequences": "^26.0.0",
             "jest-get-type": "^26.0.0",
-            "pretty-format": "^26.1.0"
+            "pretty-format": "^26.2.0"
           }
         },
         "jest-get-type": {
@@ -6694,12 +6738,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",
-          "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+          "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.1.0",
+            "@jest/types": "^26.2.0",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -6708,12 +6752,13 @@
       }
     },
     "jest-util": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.1.0.tgz",
-      "integrity": "sha512-rNMOwFQevljfNGvbzNQAxdmXQ+NawW/J72dmddsK0E8vgxXCMtwQ/EH0BiWEIxh0hhMcTsxwAxINt7Lh46Uzbg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.2.0.tgz",
+      "integrity": "sha512-YmDwJxLZ1kFxpxPfhSJ0rIkiZOM0PQbRcfH0TzJOhqCisCAsI1WcmoQqO83My9xeVA2k4n+rzg2UuexVKzPpig==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "is-ci": "^2.0.0",
@@ -6721,13 +6766,14 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6788,27 +6834,28 @@
       }
     },
     "jest-validate": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.1.0.tgz",
-      "integrity": "sha512-WPApOOnXsiwhZtmkDsxnpye+XLb/tUISP+H6cHjfUIXvlG+eKwP+isnivsxlHCPaO9Q5wvbhloIBkdF3qUn+Nw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.2.0.tgz",
+      "integrity": "sha512-8XKn3hM6VIVmLNuyzYLCPsRCT83o8jMZYhbieh4dAyKLc4Ypr36rVKC+c8WMpWkfHHpGnEkvWUjjIAyobEIY/Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
         "camelcase": "^6.0.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^26.0.0",
         "leven": "^3.1.0",
-        "pretty-format": "^26.1.0"
+        "pretty-format": "^26.2.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6836,12 +6883,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",
-          "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+          "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.1.0",
+            "@jest/types": "^26.2.0",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -6850,27 +6897,29 @@
       }
     },
     "jest-watcher": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.1.0.tgz",
-      "integrity": "sha512-ffEOhJl2EvAIki613oPsSG11usqnGUzIiK7MMX6hE4422aXOcVEG3ySCTDFLn1+LZNXGPE8tuJxhp8OBJ1pgzQ==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.2.0.tgz",
+      "integrity": "sha512-674Boco4Joe0CzgKPL6K4Z9LgyLx+ZvW2GilbpYb8rFEUkmDGgsZdv1Hv5rxsRpb1HLgKUOL/JfbttRCuFdZXQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.1.0",
-        "@jest/types": "^26.1.0",
+        "@jest/test-result": "^26.2.0",
+        "@jest/types": "^26.2.0",
+        "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^26.1.0",
+        "jest-util": "^26.2.0",
         "string-length": "^4.0.1"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+          "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
           }
@@ -6888,19 +6937,20 @@
       }
     },
     "jest-worker": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.1.0.tgz",
-      "integrity": "sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==",
+      "version": "26.2.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.2.1.tgz",
+      "integrity": "sha512-+XcGMMJDTeEGncRb5M5Zq9P7K4sQ1sirhjdOxsN1462h6lFo9w59bl2LVQmdGEEeU3m+maZCkS2Tcc9SfCHO4A==",
       "dev": true,
       "requires": {
+        "@types/node": "*",
         "merge-stream": "^2.0.0",
         "supports-color": "^7.0.0"
       }
     },
     "jpeg-js": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
-      "integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.1.tgz",
+      "integrity": "sha512-jA55yJiB5tCXEddos8JBbvW+IMrqY0y1tjjx9KNVtA+QPmu7ND5j0zkKopClpUTsaETL135uOM2XfcYG4XRjmw==",
       "dev": true
     },
     "js-tokens": {
@@ -7713,9 +7763,9 @@
       },
       "dependencies": {
         "uuid": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
-          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==",
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
           "dev": true,
           "optional": true
         }
@@ -8261,16 +8311,15 @@
       }
     },
     "playwright": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.2.1.tgz",
-      "integrity": "sha512-wD5WZ3rNvmXq+W4qhwykrm8J7VGYsjMjdC2WjZb4B4r7j/IFzq6EhliD+ZBIl+HOymFNsTwPZYhXy7IqeC2+YQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.3.0.tgz",
+      "integrity": "sha512-W3mwXv2XNFugbepSZTZxI314WfI1SAjdZBEeGOu8S5KnPz4RSlunUFgXn6496o8lobPmORLcJ9VTSGyiFfGpaw==",
       "dev": true,
       "requires": {
-        "commander": "^5.1.0",
         "debug": "^4.1.1",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
-        "jpeg-js": "^0.3.7",
+        "jpeg-js": "^0.4.0",
         "mime": "^2.4.4",
         "pngjs": "^5.0.0",
         "progress": "^2.0.3",
@@ -8279,12 +8328,6 @@
         "ws": "^6.1.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-          "dev": true
-        },
         "mime": {
           "version": "2.4.6",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
@@ -8327,14 +8370,14 @@
       "dev": true
     },
     "portfinder": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.27.tgz",
-      "integrity": "sha512-bJ3U3MThKnyJ9Dx1Idtm5pQmxXqw08+XOHhi/Lie8OF1OlhVaBFhsntAIhkZYjfDcCzszSr0w1yCbccThhzgxQ==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
         "debug": "^3.1.1",
-        "mkdirp": "^0.5.1"
+        "mkdirp": "^0.5.5"
       },
       "dependencies": {
         "debug": {
@@ -10008,9 +10051,9 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "26.1.3",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.1.3.tgz",
-      "integrity": "sha512-beUTSvuqR9SmKQEylewqJdnXWMVGJRFqSz2M8wKJe7GBMmLZ5zw6XXKSJckbHNMxn+zdB3guN2eOucSw2gBMnw==",
+      "version": "26.1.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.1.4.tgz",
+      "integrity": "sha512-Nd7diUX6NZWfWq6FYyvcIPR/c7GbEF75fH1R6coOp3fbNzbRJBZZAn0ueVS0r8r9ral1VcrpneAFAwB3TsVS1Q==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -10063,9 +10106,9 @@
       }
     },
     "tsconfig-paths-webpack-plugin": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.2.0.tgz",
-      "integrity": "sha512-S/gOOPOkV8rIL4LurZ1vUdYCVgo15iX9ZMJ6wx6w2OgcpT/G4wMyHB6WM+xheSqGMrWKuxFul+aXpCju3wmj/g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.3.0.tgz",
+      "integrity": "sha512-MpQeZpwPY4gYASCUjY4yt2Zj8yv86O8f++3Ai4o0yI0fUC6G1syvnL9VuY71PBgimRYDQU47f12BEmJq9wRaSw==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
@@ -10264,9 +10307,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
+      "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
       "dev": true,
       "optional": true
     },
@@ -10748,9 +10791,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.0.tgz",
-      "integrity": "sha512-wAuJxK123sqAw31SpkPiPW3iKHgFUiKvO7E7UZjtdExcsRe3fgav4mvoMM7vvpjLHVoJ6a0Mtp2fzkoA13e0Zw==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
+      "integrity": "sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "npm run clean && tsc && tsc -m es6 --outDir lib-esm && webpack --env.DEV=no",
     "clean": "shx rm -rf bundles docs lib lib-esm coverage",
-    "clean:all": "npm run clean && shx rm -rf node_modules package-lock.json && git clean -fX",
+    "clean:all": "npm run clean && shx rm -rf node_modules package-lock.json && git clean -fX -e '!*.pem'",
     "docs": "typedoc",
     "docs:watch": "watch 'npm run docs' ./src",
     "lint": "eslint --ignore-path .gitignore '**/*.ts' --fix",

--- a/src/fr-auth/callbacks/attribute-input-callback.ts
+++ b/src/fr-auth/callbacks/attribute-input-callback.ts
@@ -47,7 +47,9 @@ class AttributeInputCallback<T extends string | number | boolean> extends FRCall
   /**
    * Gets the callback's applicable policies.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public getPolicies(): StringDict<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return this.getOutputByName<StringDict<any>>('policies', {});
   }
 

--- a/src/fr-auth/callbacks/validated-create-password-callback.ts
+++ b/src/fr-auth/callbacks/validated-create-password-callback.ts
@@ -23,7 +23,9 @@ class ValidatedCreatePasswordCallback extends FRCallback {
   /**
    * Gets the callback's applicable policies.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public getPolicies(): StringDict<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return this.getOutputByName<StringDict<any>>('policies', {});
   }
 

--- a/src/fr-auth/callbacks/validated-create-username-callback.ts
+++ b/src/fr-auth/callbacks/validated-create-username-callback.ts
@@ -30,7 +30,9 @@ class ValidatedCreateUsernameCallback extends FRCallback {
   /**
    * Gets the callback's applicable policies.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public getPolicies(): StringDict<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return this.getOutputByName<StringDict<any>>('policies', {});
   }
 

--- a/src/oauth2-client/index.ts
+++ b/src/oauth2-client/index.ts
@@ -25,6 +25,8 @@ abstract class OAuth2Client {
    * Gets the authorization URL configured in OpenAM, optionally using PKCE.
    */
   public static async getAuthorizeUrl(options: GetAuthorizationUrlOptions): Promise<string> {
+    console.warn('Deprecation warning: this `getAuthorizeUrl` method will be renamed in v3.');
+
     const { serverConfig, clientId, redirectUri, scope } = Config.get(options);
 
     /* eslint-disable @typescript-eslint/camelcase */

--- a/src/token-manager/index.ts
+++ b/src/token-manager/index.ts
@@ -2,7 +2,6 @@ import { ConfigOptions } from '../config';
 import OAuth2Client, { OAuth2Tokens, ResponseType } from '../oauth2-client';
 import { Tokens } from '../shared/interfaces';
 import TokenStorage from '../token-storage';
-import nonce from '../util/nonce';
 import PKCE from '../util/pkce';
 import { parseQuery } from '../util/url';
 
@@ -27,7 +26,7 @@ abstract class TokenManager {
     }
 
     const verifier = PKCE.createVerifier();
-    const state = nonce()().toString();
+    const state = PKCE.createState();
     const authorizeUrlOptions = { ...options, responseType: ResponseType.Code, state, verifier };
     const authorizeUrl = await OAuth2Client.getAuthorizeUrl(authorizeUrlOptions);
 

--- a/src/util/nonce.ts
+++ b/src/util/nonce.ts
@@ -4,6 +4,8 @@
  * @param length The number of digits to generate
  */
 function nonce(length = 15): () => number {
+  console.warn('Deprecation warning: the `nonce` method will be removed in v3.');
+
   let last = -1;
   let repeat = 0;
 

--- a/src/util/pkce.ts
+++ b/src/util/pkce.ts
@@ -1,18 +1,23 @@
 /**
- * Helper class for generating verifier and challenge strings used for
+ * Helper class for generating verifier, challenge and state strings used for
  * Proof Key for Code Exchange (PKCE).
  */
 abstract class PKCE {
   /**
-   * Creates a random verifier.
-   *
-   * @param size The length of the verifier (default 32 characters)
+   * Creates a random state.
    */
-  public static createVerifier(size = 32): string {
-    const array = new Uint8Array(size);
-    window.crypto.getRandomValues(array);
-    const verifier = this.base64UrlEncode(array);
-    return verifier;
+  public static createState(): string {
+    return this.createRandomString(16);
+  }
+
+  /**
+   * Creates a random verifier.
+   */
+  public static createVerifier(num?: number): string {
+    if (num) {
+      console.warn('Deprecation warning: the parameter for `createVerifier` will be removed in v3');
+    }
+    return this.createRandomString(num || 32);
   }
 
   /**
@@ -48,6 +53,16 @@ abstract class PKCE {
     const hashBuffer = await window.crypto.subtle.digest('SHA-256', uint8Array);
     const hashArray = new Uint8Array(hashBuffer);
     return hashArray;
+  }
+  /**
+   * Creates a random string.
+   *
+   * @param size The number for entropy (default: 32)
+   */
+  private static createRandomString(num = 32): string {
+    const random = new Uint8Array(num);
+    window.crypto.getRandomValues(random);
+    return btoa(random.join('')).replace(/[^a-zA-Z0-9]+/, '');
   }
 }
 


### PR DESCRIPTION
**Summary**:

To improve the security of the PKCE flow, we are introducing a higher entropy verifier and state string generation. We are also deprecating the `nonce` utility and `getAuthorizeUrl` method in a future version.

**Details**:

1. Added deprecation message to `nonce` and `getAuthorizeUrl`, but left it in the API to ensure no breakage
2. Utilize stronger entropy in string generation for verifier and state for PKCE flow