### PR TITLE
Fix (tokens/logout/automation): revoke tokens before renewing, refactor logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Centralized login support has been added
+- OAuth authorize endpoint now supports both iframe and fetch through the new `support` property in the config
+
+### Fixed
+
+- `step.getStage()` is no longer used in sample app; `getStage(step)` is now used for better compatibility with AM 6.5
+- `FRUser.logout` now uses a try-catch around each endpoint call, rather than a single try-catch
+- Paths for sample app now point to correct favicon image
+- Improved automation testing
+
 ## [2.1.0] - 2020-08-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "npm run test:unit && npm run test:integration && npm run test:e2e",
     "test:coverage": "jest --testMatch='<rootDir>/src/**/*.test.ts' --config=./tests/jest.basic.config.js --coverage=true",
     "test:e2e": "jest --testMatch='<rootDir>/tests/e2e/**/*.test.ts' --config=./tests/jest.e2e.config.js",
-    "test:e2e:live": "LIVE=true jest --testMatch='<rootDir>/tests/e2e/**/authn-basic.lc.test.ts' --config=./tests/jest.e2e.config.js",
+    "test:e2e:live": "LIVE=true jest --testMatch='<rootDir>/tests/e2e/**/*.lc.test.ts' --config=./tests/jest.e2e.config.js",
     "test:integration": "jest --testMatch='<rootDir>/tests/integration/**/*.test.ts' --config=./tests/jest.basic.config.js",
     "test:unit": "jest --testMatch='<rootDir>/src/**/*.test.ts' --config=./tests/jest.basic.config.js --env=./tests/jest.env.config.js",
     "watch": "webpack -w --env.DEV=yes"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "npm run test:unit && npm run test:integration && npm run test:e2e",
     "test:coverage": "jest --testMatch='<rootDir>/src/**/*.test.ts' --config=./tests/jest.basic.config.js --coverage=true",
     "test:e2e": "jest --testMatch='<rootDir>/tests/e2e/**/*.test.ts' --config=./tests/jest.e2e.config.js",
-    "test:e2e:live": "LIVE=true jest --testMatch='<rootDir>/tests/e2e/**/*.lc.test.ts' --config=./tests/jest.e2e.config.js",
+    "test:e2e:live": "LIVE=true jest --testMatch='<rootDir>/tests/e2e/**/authn-basic.lc.test.ts' --config=./tests/jest.e2e.config.js",
     "test:integration": "jest --testMatch='<rootDir>/tests/integration/**/*.test.ts' --config=./tests/jest.basic.config.js",
     "test:unit": "jest --testMatch='<rootDir>/src/**/*.test.ts' --config=./tests/jest.basic.config.js --env=./tests/jest.env.config.js",
     "watch": "webpack -w --env.DEV=yes"

--- a/samples/central-login/index.html
+++ b/samples/central-login/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Custom UI | ForgeRock JavaScript SDK Samples</title>
-  <link rel="shortcut icon" href="../img/fr-ico.png" type="image/png">
+  <link rel="shortcut icon" href="../_static/img/fr-ico.png" type="image/png">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
   <style>
     body {

--- a/samples/custom-ui/index.html
+++ b/samples/custom-ui/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Custom UI | ForgeRock JavaScript SDK Samples</title>
-  <link rel="shortcut icon" href="../img/fr-ico.png" type="image/png">
+  <link rel="shortcut icon" href="../_static/img/fr-ico.png" type="image/png">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
   <style>
     body {
@@ -57,7 +57,7 @@
      * of the MIT license. See the LICENSE file for details.
      */
 
-const FATAL = 'Fatal';
+    const FATAL = 'Fatal';
 
     forgerock.Config.set({
       clientId: '<Your OAuth Client>', // e.g. 'ForgeRockSDKClient'
@@ -110,6 +110,18 @@ const FATAL = 'Fatal';
       showStep('User')
     }
 
+    const getStage = (step) => {
+      // Check if the step contains callbacks for capturing username and password
+      const usernameCallbacks = step.getCallbacksOfType('NameCallback');
+      const passwordCallbacks = step.getCallbacksOfType('PasswordCallback');
+
+      if (usernameCallbacks.length && passwordCallbacks.length) {
+        return "UsernamePassword";
+      }
+
+      return undefined;
+    };
+
     // Display and bind the handler for this stage
     const handleStep = async (step) => {
       switch (step.type) {
@@ -126,7 +138,7 @@ const FATAL = 'Fatal';
           return;
 
         default:
-          const stage = step.getStage() || FATAL;
+          const stage = getStage(step) || FATAL;
           if (!showStep(stage)) {
             showStep(FATAL);
             handlers[FATAL](step);

--- a/samples/index.html
+++ b/samples/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <title>ForgeRock JavaScript SDK Samples</title>
-  <link rel="shortcut icon" href="img/fr-ico.png" type="image/png">
+  <link rel="shortcut icon" href="_static/img/fr-ico.png" type="image/png">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
 </head>
 

--- a/tests/e2e/app/authn-central-login/autoscript.js
+++ b/tests/e2e/app/authn-central-login/autoscript.js
@@ -28,7 +28,7 @@
   forgerock.Config.set({
     clientId,
     realmPath,
-    redirectUri: `${url.origin}/_callback`,
+    redirectUri: `${url.origin}/_callback/`,
     scope,
     serverConfig: {
       baseUrl: amUrl,

--- a/tests/e2e/app/authz-tree-oauth/autoscript.js
+++ b/tests/e2e/app/authz-tree-oauth/autoscript.js
@@ -30,7 +30,7 @@
   console.log('Configure the SDK');
   forgerock.Config.set({
     clientId,
-    redirectUri: `${url.origin}/_callback`,
+    redirectUri: `${url.origin}/_callback/`,
     realmPath,
     scope,
     tree,

--- a/tests/e2e/app/authz-txn-oauth/autoscript.js
+++ b/tests/e2e/app/authz-txn-oauth/autoscript.js
@@ -30,7 +30,7 @@
   console.log('Configure the SDK');
   forgerock.Config.set({
     clientId,
-    redirectUri: `${url.origin}/_callback`,
+    redirectUri: `${url.origin}/_callback/`,
     realmPath,
     scope,
     tree,

--- a/tests/e2e/app/config-custom-paths/autoscript.js
+++ b/tests/e2e/app/config-custom-paths/autoscript.js
@@ -27,7 +27,7 @@
   console.log('Configure the SDK');
   forgerock.Config.set({
     clientId,
-    redirectUri: `${url.origin}/_callback`,
+    redirectUri: `${url.origin}/_callback/`,
     realmPath,
     scope,
     tree,
@@ -36,7 +36,7 @@
       paths: {
         authenticate: 'auth/authenticate',
         authorize: 'auth/authorize',
-        accessToken: 'auth/accessToken',
+        accessToken: 'auth/tokenExchange',
         endSession: 'auth/endSession',
         userInfo: 'auth/userInfo',
         revoke: 'auth/revoke',

--- a/tests/e2e/app/config-request-middleware/autoscript.js
+++ b/tests/e2e/app/config-request-middleware/autoscript.js
@@ -47,7 +47,7 @@
         next();
       },
     ],
-    redirectUri: `${url.origin}/_callback`,
+    redirectUri: `${url.origin}/_callback/`,
     realmPath,
     scope,
     serverConfig: {

--- a/tests/e2e/app/ie11/index.js
+++ b/tests/e2e/app/ie11/index.js
@@ -71,7 +71,7 @@ const loginTree = 'Login'; // Login tree after registration
 console.log('Configure the SDK');
 forgerock.Config.set({
   clientId: 'WebOAuthClient',
-  redirectUri: 'https://sdkapp.example.com:8443/_callback',
+  redirectUri: 'https://sdkapp.example.com:8443/_callback/',
   realmPath: 'root',
   scope: 'openid profile me.read',
   tree: 'Registration', // Don't forget to config your login tree above

--- a/tests/e2e/env.config.ts
+++ b/tests/e2e/env.config.ts
@@ -18,7 +18,8 @@ const oauth = {
   scope: 'openid profile me.read',
 };
 const origins = {
-  app: 'https://sdkapp.example.com',
+  // Ensure all domains are added to the security cert creation
+  app: process.env.LIVE ? 'https://sdkapp.petrov.ca' : 'https://sdkapp.example.com',
   forgeops: 'https://default.forgeops.petrov.ca',
   mock: 'https://auth.example.com',
   resource: 'https://api.example.com',

--- a/tests/e2e/server/app.auth.mjs
+++ b/tests/e2e/server/app.auth.mjs
@@ -15,19 +15,25 @@ import { AM_URL, REALM_PATH } from './env.config.copy.mjs';
 export let session;
 
 export async function authorizeApp({ un, pw }) {
-  const response = await request
-    .post(`${AM_URL}/json/realms/${REALM_PATH}/authenticate`)
-    .key(key)
-    .cert(cert)
-    .set('Content-Type', 'application/json')
-    .set('Accept-API-Version', 'resource=2.0, protocol=1.0')
-    .set('X-OpenAM-Username', un)
-    .set('X-OpenAM-Password', pw)
-    .send({});
+  try {
+    const response = await request
+      .post(`${AM_URL}/json/realms/${REALM_PATH}/authenticate`)
+      .key(key)
+      .cert(cert)
+      .set('Content-Type', 'application/json')
+      .set('Accept-API-Version', 'resource=2.0, protocol=1.0')
+      .set('X-OpenAM-Username', un)
+      .set('X-OpenAM-Password', pw)
+      .send({});
 
-  session = response.body;
+    session = response.body;
 
-  console.log(`REST app identity token: ${session.tokenId}`);
+    console.log(`REST app identity token: ${session.tokenId}`);
 
-  return session;
+    return session;
+  } catch (error) {
+    console.warn('\n###################################################');
+    console.warn('WARNING: REST app user for Step Up/Txn Auth missing');
+    console.warn('###################################################\n');
+  }
 }

--- a/tests/e2e/server/constants.mjs
+++ b/tests/e2e/server/constants.mjs
@@ -9,7 +9,7 @@
  */
 
 export const authPaths = {
-  accessToken: ['/am/auth/accessToken', '/am/oauth2/realms/root/access_token'],
+  tokenExchange: ['/am/auth/tokenExchange', '/am/oauth2/realms/root/access_token'],
   authenticate: ['/am/auth/authenticate', '/am/json/realms/root/authenticate'],
   htmlAuthenticate: ['/am/'],
   authorize: ['/am/auth/authorize', '/am/oauth2/realms/root/authorize'],

--- a/tests/e2e/server/env.config.copy.mjs
+++ b/tests/e2e/server/env.config.copy.mjs
@@ -35,6 +35,7 @@ const ports = {
 const realm = 'root';
 const testUsers = [
   {
+    // Already exists in forgeops...
     pw: 'password',
     un: 'sdkuser',
   },

--- a/tests/e2e/server/env.config.copy.mjs
+++ b/tests/e2e/server/env.config.copy.mjs
@@ -18,7 +18,8 @@ const oauth = {
   scope: 'openid profile me.read',
 };
 const origins = {
-  app: 'https://sdkapp.example.com',
+  // Ensure all domains are added to the security cert creation
+  app: process.env.LIVE ? 'https://sdkapp.petrov.ca' : 'https://sdkapp.example.com',
   forgeops: 'https://default.forgeops.petrov.ca',
   mock: 'https://auth.example.com',
   resource: 'https://api.example.com',

--- a/tests/e2e/server/responses.mjs
+++ b/tests/e2e/server/responses.mjs
@@ -10,7 +10,7 @@
 
 import { AM_URL, RESOURCE_URL } from './env.config.copy.mjs';
 
-export const accessToken = {
+export const oauthTokens = {
   access_token: 'baz',
   scope: 'openid profile me.read',
   id_token: 'mox',

--- a/tests/e2e/server/routes.auth.mjs
+++ b/tests/e2e/server/routes.auth.mjs
@@ -8,10 +8,11 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
+import { v4 } from 'uuid';
 import { authPaths } from './constants.mjs';
 import { AM_URL, USERS } from './env.config.copy.mjs';
 import {
-  accessToken,
+  oauthTokens,
   authFail,
   authSuccess,
   emailSuspend,
@@ -215,8 +216,12 @@ export default function (app) {
     }
   });
 
-  app.post(authPaths.accessToken, wait, async (req, res) => {
-    res.json(accessToken);
+  app.post(authPaths.tokenExchange, wait, async (req, res) => {
+    // eslint-disable-next-line
+    const access_token = v4();
+    // eslint-disable-next-line
+    const tokens = { ...oauthTokens, access_token };
+    res.json(tokens);
   });
 
   app.get(authPaths.authorize, wait, async (req, res) => {

--- a/tests/e2e/suites/authn-basic.lc.neg.test.ts
+++ b/tests/e2e/suites/authn-basic.lc.neg.test.ts
@@ -9,27 +9,25 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test bad login flow', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`Login UNsuccessfully with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'authn-basic/', {
-        pw: 'wrong_password_123!',
-      });
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'authn-basic/', {
+          pw: 'wrong_password_123!',
+          selector: '.Auth_Error',
+        });
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('Error: Auth_Error')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      await page.waitForSelector('.Auth_Error');
-
-      // Test assertions
-      expect(messageArray.includes('Error: Auth_Error')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/authn-basic.lc.test.ts
+++ b/tests/e2e/suites/authn-basic.lc.test.ts
@@ -9,33 +9,25 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test Basic login flow', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`should login successfully and then log out with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'authn-basic/');
-
-      const messageArray = [];
-
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
       try {
-        await page.waitForSelector('.Test_Complete');
+        const { browser, messageArray } = await setupAndGo(browserType, 'authn-basic/');
+
+        // Test assertions
+        expect(messageArray.includes('Basic login successful')).toBe(true);
+        expect(messageArray.includes('Logout successful')).toBe(true);
+        expect(messageArray.includes('Starting authentication with service')).toBe(true);
+        expect(messageArray.includes('Continuing authentication with service')).toBe(true);
+
+        await browser.close();
+        done();
       } catch (error) {
-        browser.close();
-        return done.fail();
+        done(error);
       }
-
-      // Test assertions
-      expect(messageArray.includes('Basic login successful')).toBe(true);
-      expect(messageArray.includes('Logout successful')).toBe(true);
-      expect(messageArray.includes('Starting authentication with service')).toBe(true);
-      expect(messageArray.includes('Continuing authentication with service')).toBe(true);
-
-      await browser.close();
-      done();
     });
   });
 });

--- a/tests/e2e/suites/authn-basic.lc.test.ts
+++ b/tests/e2e/suites/authn-basic.lc.test.ts
@@ -21,7 +21,12 @@ describe('Test Basic login flow', () => {
         messageArray.push(msg.text());
       });
 
-      await page.waitForSelector('.Test_Complete');
+      try {
+        await page.waitForSelector('.Test_Complete');
+      } catch (error) {
+        browser.close();
+        return done.fail();
+      }
 
       // Test assertions
       expect(messageArray.includes('Basic login successful')).toBe(true);

--- a/tests/e2e/suites/authn-central-login.test.ts
+++ b/tests/e2e/suites/authn-central-login.test.ts
@@ -9,100 +9,80 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test OAuth login flow', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     // eslint-disable-next-line
     it(`should use invisible iframe to request auth code, then token exchange with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'authn-central-login/');
+      try {
+        const { browser, messageArray, networkArray } = await setupAndGo(
+          browserType,
+          'authn-central-login/',
+        );
 
-      const messageArray = [];
-      const networkArray = [];
+        // Test assertions
+        // Test log messages
+        expect(messageArray.includes('OAuth authorization successful')).toBe(true);
+        expect(messageArray.includes('Test script complete')).toBe(true);
+        // Test network requests
+        // Authorize endpoint should use iframe, which is type "document"
+        expect(networkArray.includes('/am/oauth2/realms/root/authorize, document')).toBe(true);
+        expect(networkArray.includes('/am/oauth2/realms/root/access_token, fetch')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-      page.on('request', (req) => {
-        networkArray.push(`${new URL(req.url()).pathname}, ${req.resourceType()}`);
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      // Test log messages
-      expect(messageArray.includes('OAuth authorization successful')).toBe(true);
-      expect(messageArray.includes('Test script complete')).toBe(true);
-      // Test network requests
-      // Authorize endpoint should use iframe, which is type "document"
-      expect(networkArray.includes('/am/oauth2/realms/root/authorize, document')).toBe(true);
-      expect(networkArray.includes('/am/oauth2/realms/root/access_token, fetch')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
 
     // eslint-disable-next-line
     it(`should use fetch to request auth code, then token exchange with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(
-        browserType,
-        'authn-central-login/?support=modern',
-      );
+      try {
+        const { browser, messageArray, networkArray } = await setupAndGo(
+          browserType,
+          'authn-central-login/?support=modern',
+        );
 
-      const messageArray = [];
-      const networkArray = [];
+        // Test assertions
+        // Test log messages
+        expect(messageArray.includes('OAuth authorization successful')).toBe(true);
+        expect(messageArray.includes('Test script complete')).toBe(true);
+        // Test network requests
+        expect(networkArray.includes('/am/oauth2/realms/root/authorize, fetch')).toBe(true);
+        expect(networkArray.includes('/am/oauth2/realms/root/access_token, fetch')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-      page.on('request', (req) => {
-        networkArray.push(`${new URL(req.url()).pathname}, ${req.resourceType()}`);
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      // Test log messages
-      expect(messageArray.includes('OAuth authorization successful')).toBe(true);
-      expect(messageArray.includes('Test script complete')).toBe(true);
-      // Test network requests
-      expect(networkArray.includes('/am/oauth2/realms/root/authorize, fetch')).toBe(true);
-      expect(networkArray.includes('/am/oauth2/realms/root/access_token, fetch')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
 
     // eslint-disable-next-line
     it(`should successfully take code & state params for token exchange with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(
-        browserType,
-        'authn-central-login/?state=abc&code=xyz',
-      );
+      try {
+        const { browser, messageArray, networkArray } = await setupAndGo(
+          browserType,
+          'authn-central-login/?state=abc&code=xyz',
+        );
 
-      const messageArray = [];
-      const networkArray = [];
+        // Test assertions
+        // Test log messages
+        expect(messageArray.includes('OAuth authorization successful')).toBe(true);
+        expect(messageArray.includes('Test script complete')).toBe(true);
+        // Test network requests
+        // Authorize endpoint should NOT be called using document or fetch
+        expect(networkArray.includes('/am/oauth2/realms/root/authorize, document')).toBe(false);
+        expect(networkArray.includes('/am/oauth2/realms/root/authorize, fetch')).toBe(false);
+        expect(networkArray.includes('/am/oauth2/realms/root/access_token, fetch')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-      page.on('request', (req) => {
-        networkArray.push(`${new URL(req.url()).pathname}, ${req.resourceType()}`);
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      // Test log messages
-      expect(messageArray.includes('OAuth authorization successful')).toBe(true);
-      expect(messageArray.includes('Test script complete')).toBe(true);
-      // Test network requests
-      // Authorize endpoint should NOT be called using document or fetch
-      expect(networkArray.includes('/am/oauth2/realms/root/authorize, document')).toBe(false);
-      expect(networkArray.includes('/am/oauth2/realms/root/authorize, fetch')).toBe(false);
-      expect(networkArray.includes('/am/oauth2/realms/root/access_token, fetch')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/authn-device-profile.lc.test.ts
+++ b/tests/e2e/suites/authn-device-profile.lc.test.ts
@@ -9,30 +9,26 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test bad login flow', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`Login with device profile callback ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'authn-device-profile/', {
-        allowGeo: true,
-        tree: 'DeviceProfileCallbackTest',
-      });
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'authn-device-profile/', {
+          allowGeo: true,
+        });
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('Collecting profile ...')).toBe(true);
+        expect(messageArray.includes('Profile collected.')).toBe(true);
+        expect(messageArray.includes('Login with profile successful.')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('Collecting profile ...')).toBe(true);
-      expect(messageArray.includes('Profile collected.')).toBe(true);
-      expect(messageArray.includes('Login with profile successful.')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/authn-email-suspend.test.ts
+++ b/tests/e2e/suites/authn-email-suspend.test.ts
@@ -9,34 +9,27 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test basic registration flow', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`should register user successfully and then log out with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'authn-email-suspend/');
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'authn-email-suspend/');
 
-      const messageArray = [];
+        // Test assertions
+        expect(
+          messageArray.includes(
+            // eslint-disable-next-line max-len
+            'An email has been sent to the address you entered. Click the link in that email to proceed.',
+          ),
+        ).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      page.on('dialog', async (dialog) => {
-        await dialog.accept('abcd1234');
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(
-        messageArray.includes(
-          // eslint-disable-next-line max-len
-          'An email has been sent to the address you entered. Click the link in that email to proceed.',
-        ),
-      ).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/authn-no-session.lc.test.ts
+++ b/tests/e2e/suites/authn-no-session.lc.test.ts
@@ -9,28 +9,25 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test Basic login flow', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`should login successfully and then log out with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'authn-no-session/');
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'authn-no-session/');
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('Adding "noSession" query param to URL')).toBe(true);
+        expect(messageArray.includes('Basic login with "noSession" completed successfully')).toBe(
+          true,
+        );
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('Adding "noSession" query param to URL')).toBe(true);
-      expect(messageArray.includes('Basic login with "noSession" completed successfully')).toBe(
-        true,
-      );
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/authn-oauth.lc.test.ts
+++ b/tests/e2e/suites/authn-oauth.lc.test.ts
@@ -9,28 +9,38 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test OAuth login flow', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`should login successfully and then log out with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'authn-oauth/');
+      try {
+        const { browser, messageArray, networkArray } = await setupAndGo(
+          browserType,
+          'authn-oauth/',
+        );
 
-      const messageArray = [];
+        // Test assertions
+        // Test log messages
+        expect(messageArray.includes('OAuth login successful')).toBe(true);
+        expect(messageArray.includes('Logout successful')).toBe(true);
+        expect(messageArray.includes('Calling authorize endpoint')).toBe(true);
+        expect(messageArray.includes('Calling access token exchange endpoint')).toBe(true);
+        expect(messageArray.includes('Get user info from OAuth endpoint')).toBe(true);
+        expect(messageArray.includes('New OAuth tokens retrieved')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
+        // Test network requests
+        // Make sure revoke request is made twice, one for force renew and one for logout
+        const revokeRequests = networkArray.filter(
+          (request) => request === '/am/oauth2/realms/root/token/revoke, fetch',
+        );
+        expect(revokeRequests.length).toBe(2);
 
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('OAuth login successful')).toBe(true);
-      expect(messageArray.includes('Logout successful')).toBe(true);
-      expect(messageArray.includes('Calling authorize endpoint')).toBe(true);
-      expect(messageArray.includes('Calling access token exchange endpoint')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/authn-platform.lc.test.ts
+++ b/tests/e2e/suites/authn-platform.lc.test.ts
@@ -9,26 +9,23 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test Basic login flow', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`should login successfully and then log out with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'authn-platform/');
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'authn-platform/');
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('Basic login with platform nodes successful')).toBe(true);
+        expect(messageArray.includes('Logout successful')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('Basic login with platform nodes successful')).toBe(true);
-      expect(messageArray.includes('Logout successful')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/authn-second-factor.test.ts
+++ b/tests/e2e/suites/authn-second-factor.test.ts
@@ -9,31 +9,24 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test Second Factor login flow', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`should login successfully with OTP and then log out with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'authn-second-factor/');
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'authn-second-factor/');
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('Set given OTP to password callback')).toBe(true);
+        expect(messageArray.includes('Logout successful')).toBe(true);
+        expect(messageArray.includes('Second Factor login successful')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      page.on('dialog', async (dialog) => {
-        await dialog.accept('abc123');
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('Set given OTP to password callback')).toBe(true);
-      expect(messageArray.includes('Logout successful')).toBe(true);
-      expect(messageArray.includes('Second Factor login successful')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/authz-tree-basic.test.ts
+++ b/tests/e2e/suites/authz-tree-basic.test.ts
@@ -9,30 +9,27 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test Transaction Authorization flow', () => {
-  ['chromium' /*, 'webkit' */].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`Trigger Txn Auth appropriately with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'authz-txn-basic/');
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'authz-txn-basic/');
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('IG resource requires additional authorization')).toBe(true);
+        expect(messageArray.includes('Rest resource requires additional authorization')).toBe(true);
+        expect(messageArray.includes('Request to IG resource successfully responded')).toBe(true);
+        expect(messageArray.includes('Request to REST resource successfully responded')).toBe(true);
+        expect(messageArray.includes('Starting authentication with composite advice')).toBe(true);
+        expect(messageArray.includes('Continuing authentication with composite advice')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('IG resource requires additional authorization')).toBe(true);
-      expect(messageArray.includes('Rest resource requires additional authorization')).toBe(true);
-      expect(messageArray.includes('Request to IG resource successfully responded')).toBe(true);
-      expect(messageArray.includes('Request to REST resource successfully responded')).toBe(true);
-      expect(messageArray.includes('Starting authentication with composite advice')).toBe(true);
-      expect(messageArray.includes('Continuing authentication with composite advice')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/authz-txn-basic.test.ts
+++ b/tests/e2e/suites/authz-txn-basic.test.ts
@@ -9,30 +9,27 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test Transaction Authorization flow', () => {
-  ['chromium' /*, 'webkit' */].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`Trigger Txn Auth appropriately with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'authz-txn-basic/');
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'authz-txn-basic/');
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('IG resource requires additional authorization')).toBe(true);
+        expect(messageArray.includes('Rest resource requires additional authorization')).toBe(true);
+        expect(messageArray.includes('Request to IG resource successfully responded')).toBe(true);
+        expect(messageArray.includes('Request to REST resource successfully responded')).toBe(true);
+        expect(messageArray.includes('Starting authentication with composite advice')).toBe(true);
+        expect(messageArray.includes('Continuing authentication with composite advice')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('IG resource requires additional authorization')).toBe(true);
-      expect(messageArray.includes('Rest resource requires additional authorization')).toBe(true);
-      expect(messageArray.includes('Request to IG resource successfully responded')).toBe(true);
-      expect(messageArray.includes('Request to REST resource successfully responded')).toBe(true);
-      expect(messageArray.includes('Starting authentication with composite advice')).toBe(true);
-      expect(messageArray.includes('Continuing authentication with composite advice')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/config-custom-paths.test.ts
+++ b/tests/e2e/suites/config-custom-paths.test.ts
@@ -9,26 +9,23 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test OAuth login flow with custom paths', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`should login successfully and then log out with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'config-custom-paths/');
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'config-custom-paths/');
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('OAuth login successful')).toBe(true);
+        expect(messageArray.includes('Logout successful')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('OAuth login successful')).toBe(true);
-      expect(messageArray.includes('Logout successful')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/config-request-middleware.test.ts
+++ b/tests/e2e/suites/config-request-middleware.test.ts
@@ -9,26 +9,26 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test request middleware with login flow', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`Login successfully with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'config-request-middleware/');
+      try {
+        const { browser, messageArray } = await setupAndGo(
+          browserType,
+          'config-request-middleware/',
+        );
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('Basic login successful')).toBe(true);
+        expect(messageArray.includes('Logout successful')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('Basic login successful')).toBe(true);
-      expect(messageArray.includes('Logout successful')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/config-token-storage.test.ts
+++ b/tests/e2e/suites/config-token-storage.test.ts
@@ -9,76 +9,62 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test oauth login flow with localStorage', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`Login successfully with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'config-token-storage/', {
-        tokenStore: 'sessionStorage',
-      });
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'config-token-storage/', {
+          tokenStore: 'sessionStorage',
+        });
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('Access token is correct')).toBe(true);
+        expect(messageArray.includes('Logout successful')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('OAuth login successful')).toBe(true);
-      expect(messageArray.includes('Access token is baz.')).toBe(true);
-      expect(messageArray.includes('Logout successful')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
 
     it(`Login successfully with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'config-token-storage/', {
-        tokenStore: 'indexedDB',
-      });
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'config-token-storage/', {
+          tokenStore: 'indexedDB',
+        });
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('Access token is correct')).toBe(true);
+        expect(messageArray.includes('Logout successful')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('OAuth login successful')).toBe(true);
-      expect(messageArray.includes('Access token is baz.')).toBe(true);
-      expect(messageArray.includes('Logout successful')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
 
     it(`Login successfully with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'config-token-storage/', {
-        tokenStore: 'customStore',
-      });
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'config-token-storage/', {
+          tokenStore: 'customStore',
+        });
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('Custom token setter used.')).toBe(true);
+        expect(messageArray.includes('Custom token getter used.')).toBe(true);
+        expect(messageArray.includes('Custom token remover used.')).toBe(true);
+        expect(messageArray.includes('Access token is correct')).toBe(true);
+        expect(messageArray.includes('Logout successful')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('OAuth login successful')).toBe(true);
-      expect(messageArray.includes('Custom token setter used.')).toBe(true);
-      expect(messageArray.includes('Custom token getter used.')).toBe(true);
-      expect(messageArray.includes('Custom token remover used.')).toBe(true);
-      expect(messageArray.includes('Access token is baz.')).toBe(true);
-      expect(messageArray.includes('Logout successful')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/misc-callbacks.lc.test.ts
+++ b/tests/e2e/suites/misc-callbacks.lc.test.ts
@@ -9,31 +9,28 @@
  */
 
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test Basic login flow', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     it(`should login successfully and then log out with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'misc-callbacks/');
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'misc-callbacks/');
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('Prompt from NameCallback is User Name')).toBe(true);
+        expect(messageArray.includes('Prompt from PasswordCallback is Password')).toBe(true);
+        expect(messageArray.includes('Choose your color')).toBe(true);
+        expect(messageArray.includes('Value of "green" is set')).toBe(true);
+        expect(messageArray.includes('Message for confirmation is: Is it true?')).toBe(true);
+        expect(messageArray.includes('Waiting for response...')).toBe(true);
+        expect(messageArray.includes('Wait time is 1000 milliseconds')).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('Prompt from NameCallback is User Name')).toBe(true);
-      expect(messageArray.includes('Prompt from PasswordCallback is Password')).toBe(true);
-      expect(messageArray.includes('Choose your color')).toBe(true);
-      expect(messageArray.includes('Value of "green" is set')).toBe(true);
-      expect(messageArray.includes('Message for confirmation is: Is it true?')).toBe(true);
-      expect(messageArray.includes('Waiting for response...')).toBe(true);
-      expect(messageArray.includes('Wait time is 1000 milliseconds')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/suites/register-basic.lc.test.ts
+++ b/tests/e2e/suites/register-basic.lc.test.ts
@@ -10,43 +10,46 @@
 
 import { v4 } from 'uuid';
 import { setupAndGo } from '../utilities/setup-and-go';
+import browsers from '../utilities/browsers';
 
 describe('Test basic registration flow', () => {
-  ['chromium', 'webkit', 'firefox'].forEach((browserType) => {
+  browsers.forEach((browserType) => {
     const un = v4();
-    const email = `${un}@me.com}`;
+    const email = `${un}@me.com`;
 
     it(`should register user successfully and then log out with ${browserType}`, async (done) => {
-      const { browser, page } = await setupAndGo(browserType, 'register-basic/', {
-        un,
-        email,
-      });
+      try {
+        const { browser, messageArray } = await setupAndGo(browserType, 'register-basic/', {
+          un,
+          email,
+        });
 
-      const messageArray = [];
+        // Test assertions
+        expect(messageArray.includes('Prompt from UsernameCallback is Username')).toBe(true);
+        expect(messageArray.includes('Prompt from PasswordCallback is Password')).toBe(true);
+        expect(messageArray.includes('Prompt 1: First Name')).toBe(true);
+        expect(messageArray.includes('Prompt 2: Last Name')).toBe(true);
+        expect(messageArray.includes('Prompt 3: Email Address')).toBe(true);
+        expect(messageArray.includes('Prompt 4: Send me special offers and services')).toBe(true);
+        expect(messageArray.includes('Prompt 5: Send me news and updates')).toBe(true);
+        // expect(messageArray.includes('Prompt 6: Age')).toBe(true);
+        expect(messageArray.includes('Prompt 7: Select a security question')).toBe(true);
+        expect(messageArray.includes(`Predefined Question1: What's your favorite color?`)).toBe(
+          true,
+        );
+        expect(messageArray.includes('Terms version: 0.0')).toBe(true);
+        expect(
+          messageArray.includes(
+            // eslint-disable-next-line
+            'Terms text: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+          ),
+        ).toBe(true);
 
-      page.on('console', (msg) => {
-        messageArray.push(msg.text());
-      });
-
-      await page.waitForSelector('.Test_Complete');
-
-      // Test assertions
-      expect(messageArray.includes('Prompt from UsernameCallback is Username')).toBe(true);
-      expect(messageArray.includes('Prompt from PasswordCallback is Password')).toBe(true);
-      expect(messageArray.includes('Prompt 1: First Name')).toBe(true);
-      expect(messageArray.includes('Prompt 2: Last Name')).toBe(true);
-      expect(messageArray.includes('Prompt 3: Email Address')).toBe(true);
-      expect(messageArray.includes('Prompt 4: Send me special offers and services')).toBe(true);
-      expect(messageArray.includes('Prompt 5: Send me news and updates')).toBe(true);
-      // expect(messageArray.includes('Prompt 6: Age')).toBe(true);
-      expect(messageArray.includes('Prompt 7: Select a security question')).toBe(true);
-      expect(messageArray.includes(`Predefined Question1: What's your favorite color?`)).toBe(true);
-      expect(messageArray.includes('Terms version: 0.0')).toBe(true);
-      // eslint-disable-next-line
-      expect(messageArray.includes('Terms text: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.')).toBe(true);
-
-      await browser.close();
-      done();
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/tests/e2e/utilities/browsers.ts
+++ b/tests/e2e/utilities/browsers.ts
@@ -1,0 +1,14 @@
+/*
+ * @forgerock/javascript-sdk
+ *
+ * browsers.ts
+ *
+ * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+// Prevent having to declare this type everywhere
+declare const browsers: string[];
+
+export default browsers;

--- a/tests/e2e/utilities/setup-and-go.ts
+++ b/tests/e2e/utilities/setup-and-go.ts
@@ -39,6 +39,7 @@ export async function setupAndGo(
     permissions: config && config.allowGeo ? ['geolocation'] : [],
   });
   const page = await context.newPage();
+  page.setDefaultTimeout(10 * 1000);
 
   const url = new URL(`${BASE_URL}/${path}`);
 

--- a/tests/e2e/utilities/setup-and-go.ts
+++ b/tests/e2e/utilities/setup-and-go.ts
@@ -20,47 +20,74 @@ export async function setupAndGo(
     allowGeo?: boolean;
     amUrl?: string;
     clientId?: string;
+    dialogInput?: string;
     email?: string;
     pw?: string;
     realmPath?: string;
     resourceUrl?: string;
+    selector?: string;
     scope?: string;
     tokenStore?: string;
     tree?: string;
     un?: string;
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Promise<{ browser: any; page: any }> {
+): Promise<{ browser: any; messageArray: string[]; networkArray: string[] }> {
   const browser = await browsers[browserType].launch({ headless: true });
-  const context = await browser.newContext({
-    bypassCSP: true,
-    geolocation: { latitude: 24.9884, longitude: -87.3459 },
-    ignoreHTTPSErrors: true,
-    permissions: config && config.allowGeo ? ['geolocation'] : [],
-  });
-  const page = await context.newPage();
-  page.setDefaultTimeout(10 * 1000);
+  const messageArray = [];
+  const networkArray = [];
 
-  const url = new URL(`${BASE_URL}/${path}`);
+  // If anything fails, ensure we close the browser to end the process
+  try {
+    const context = await browser.newContext({
+      bypassCSP: true,
+      geolocation: { latitude: 24.9884, longitude: -87.3459 },
+      ignoreHTTPSErrors: true,
+      permissions: config && config.allowGeo ? ['geolocation'] : [],
+    });
+    const page = await context.newPage();
+    page.setDefaultTimeout(10 * 1000); // 10 seconds (make be less than the Jest config timeout)
 
-  url.searchParams.set('amUrl', (config && config.amUrl) || AM_URL);
-  url.searchParams.set('clientId', (config && config.clientId) || CLIENT_ID);
-  url.searchParams.set('email', (config && config.email) || '');
-  url.searchParams.set('realmPath', (config && config.realmPath) || REALM_PATH);
-  url.searchParams.set('resourceUrl', (config && config.resourceUrl) || RESOURCE_URL);
-  url.searchParams.set('scope', (config && config.scope) || SCOPE);
-  url.searchParams.set('pw', (config && config.pw) || USERS[0].pw);
-  url.searchParams.set('tokenStore', (config && config.tokenStore) || '');
-  url.searchParams.set('tree', (config && config.tree) || '');
-  url.searchParams.set('un', (config && config.un) || USERS[0].un);
+    const url = new URL(`${BASE_URL}/${path}`);
 
-  // log out the URL used for the test, but only for chromium;
-  // the other browser URLs would just be duplicates
-  if (browserType === 'chromium') {
-    console.log(url.toString());
+    url.searchParams.set('amUrl', (config && config.amUrl) || AM_URL);
+    url.searchParams.set('clientId', (config && config.clientId) || CLIENT_ID);
+    url.searchParams.set('email', (config && config.email) || '');
+    url.searchParams.set('realmPath', (config && config.realmPath) || REALM_PATH);
+    url.searchParams.set('resourceUrl', (config && config.resourceUrl) || RESOURCE_URL);
+    url.searchParams.set('scope', (config && config.scope) || SCOPE);
+    url.searchParams.set('pw', (config && config.pw) || USERS[0].pw);
+    url.searchParams.set('tokenStore', (config && config.tokenStore) || '');
+    url.searchParams.set('tree', (config && config.tree) || '');
+    url.searchParams.set('un', (config && config.un) || USERS[0].un);
+
+    // log out the URL used for the test, but only for chromium;
+    // the other browser URLs would just be duplicates
+    if (browserType === 'chromium') {
+      console.log(url.toString());
+    }
+
+    await page.goto(url.toString());
+
+    // Listen for events on page
+    page.on('console', (msg) => {
+      messageArray.push(msg.text());
+    });
+    page.on('console', (msg) => {
+      messageArray.push(msg.text());
+    });
+    page.on('request', (req) => {
+      networkArray.push(`${new URL(req.url()).pathname}, ${req.resourceType()}`);
+    });
+    page.on('dialog', async (dialog) => {
+      await dialog.accept(config?.dialogInput || 'abc123');
+    });
+
+    await page.waitForSelector(config?.selector || '.Test_Complete');
+  } catch (error) {
+    await browser.close();
+    throw error;
   }
 
-  await page.goto(url.toString());
-
-  return { browser, page };
+  return { browser, messageArray, networkArray };
 }

--- a/tests/jest.e2e.config.js
+++ b/tests/jest.e2e.config.js
@@ -12,11 +12,12 @@ module.exports = {
   globalSetup: './tests/e2e/env.setup.js',
   globalTeardown: './tests/e2e/env.teardown.js',
   globals: {
+    browsers: ['chromium', 'webkit', 'firefox'],
     'ts-jest': {
       isolatedModules: true,
     },
   },
   preset: 'ts-jest',
-  testTimeout: 20000,
+  testTimeout: 20 * 1000, // 20 seconds (must be more than the setup-and-go.ts timeout)
   rootDir: '../',
 };

--- a/tests/jest.e2e.config.js
+++ b/tests/jest.e2e.config.js
@@ -17,6 +17,6 @@ module.exports = {
     },
   },
   preset: 'ts-jest',
-  testTimeout: 30000,
+  testTimeout: 20000,
   rootDir: '../',
 };


### PR DESCRIPTION
**Summary:**

This PR introduces a few changes:

- Revokes existing tokens when `forceRenew` is used to request a new set of OAuth tokens
- `FRUser.logout` wraps each endpoint call in its own try-catch to ensure continuation of logout, regardless of error
- Improvements to the live automation testing
- Improvements to sample application

**Details:**

Resolves the following tickets: SDKS-758, SDKS-766, SDKS-714, SDKS-724