### PR TITLE
fix (central-login): handle redirect errors with FF and Webkit

### DIFF
--- a/samples/central-login/index.html
+++ b/samples/central-login/index.html
@@ -93,7 +93,7 @@
     const logout = async () => {
       try {
         await forgerock.FRUser.logout();
-        location.assign(`${document.location.origin}/central-login`);
+        location.assign(`${document.location.origin}/central-login/`);
       } catch (error) {
         console.error(error);
       }

--- a/src/fr-device/sample-profile.json
+++ b/src/fr-device/sample-profile.json
@@ -39,7 +39,7 @@
     }
   },
   "location": {
-    "latitude": 30.49843,
-    "longitude": -97.639371
+    "latitude": 27.766237,
+    "longitude": -94.889905
   }
 }

--- a/src/oauth2-client/index.ts
+++ b/src/oauth2-client/index.ts
@@ -28,9 +28,16 @@ import {
 import middlewareWrapper from '../util/middleware';
 
 const allowedErrors = {
+  // AM error for consent requirement
   AuthenticationConsentRequired: 'Authentication or consent required',
+  // Manual iframe error
   AuthorizationTimeout: 'Authorization timed out',
+  // Chromium browser error
   FailedToFetch: 'Failed to fetch',
+  // Mozilla browser error
+  NetworkError: 'NetworkError when attempting to fetch resource.',
+  // Webkit browser error
+  CORSError: 'Cross-origin redirection',
 };
 
 /**

--- a/src/token-manager/index.ts
+++ b/src/token-manager/index.ts
@@ -166,10 +166,13 @@ abstract class TokenManager {
       if (
         allowedErrors.AuthenticationConsentRequired !== err.message &&
         allowedErrors.AuthorizationTimeout !== err.message &&
-        allowedErrors.FailedToFetch !== err.message
+        allowedErrors.FailedToFetch !== err.message &&
+        allowedErrors.NetworkError !== err.message &&
+        // Safari has a very long error message, so we check for a substring
+        !err.message.includes(allowedErrors.CORSError)
       ) {
-        // Throw if the error is NOT "Authentication or consent required" & login is "redirect"
-        // as that is a normal response and requires a redirect
+        // Throw if the error is NOT an explicitly allowed error along with redirect of true
+        // as that is a normal response and just requires a redirect
         throw err;
       }
 


### PR DESCRIPTION
Summary:

FireFox and Safari have slightly different error messages related to the redirect to the login page and CORS. Since these errors are expected and should result in a redirect, we needed to add a check for them in the flow.