### PR TITLE
Task (central-login): word change from 'native' to 'embedded'

### DIFF
--- a/samples/central-login/index.html
+++ b/samples/central-login/index.html
@@ -59,7 +59,7 @@
 
     forgerock.Config.set({
       clientId: '<Your OAuth Client>', // e.g. 'ForgeRockSDKClient'
-      redirectUri: '<Your Redirect/Callback URL>', // e.g. 'https://sdkapp.example.com:8443/_callback'
+      redirectUri: '<Your Redirect/Callback URL>', // e.g. 'https://sdkapp.example.com:8443/central-login/'
       scope: '<Your OAuth Scopes>', // e.g. 'openid profile me.read'
         serverConfig: {
         baseUrl: '<Your AM URL>', // e.g. 'https://openam.example.com:9443/openam/'
@@ -100,12 +100,22 @@
     }
 
     const authorize = async (code, state) => {
+      /**
+       *  When the user return to this app after successfully logging in,
+       * the URL will include code and state query parameters that need to
+       * be passed in to complete the OAuth flow giving the user access
+       */
       await forgerock.TokenManager.getTokens({ query: { code, state }});
       const user = await forgerock.UserManager.getCurrentUser();
       showUser(user);
     }
 
     document.querySelector('#loginBtn').addEventListener('click', async () => {
+      /**
+       * The key-value of `login: redirect` is what allows central-login.
+       * Passing no arguments or a key-value of `login: 'embedded'` means
+       * the app handles authentication locally.
+       */
       await forgerock.TokenManager.getTokens({ login: 'redirect' });
       const user = await forgerock.UserManager.getCurrentUser();
       showUser(user);
@@ -117,12 +127,19 @@
       showUser(user);
     });
 
+    /**
+     * Check URL for query parameters
+     */
     const url = new URL(document.location);
     const params = url.searchParams;
-
     const authCode = params.get('code');
     const state = params.get('state');
 
+    /**
+     * If the URL has state and authCode as query parameters, then the user
+     * returned back here after successfully logging, so call authorize with
+     * the values
+     */
     if (state && authCode) {
       authorize(authCode, state);
     }

--- a/src/token-manager/index.ts
+++ b/src/token-manager/index.ts
@@ -18,7 +18,7 @@ import { parseQuery } from '../util/url';
 
 interface GetTokensOptions extends ConfigOptions {
   forceRenew?: boolean;
-  login?: 'native' | 'redirect' | undefined;
+  login?: 'embedded' | 'redirect' | undefined;
   query?: StringDict<string>;
 }
 
@@ -27,14 +27,14 @@ abstract class TokenManager {
    * Token Manager class that provides high-level abstraction for Authorization Code flow,
    * PKCE value generation, token exchange and token storage.
    *
-   * Supports both native authentication as well as external authentication via redirects
+   * Supports both embedded authentication as well as external authentication via redirects
    *
    Example 1:
 
    ```js
    const tokens = forgerock.TokenManager.getTokens({
      forceRenew: true, // If you want to get new tokens, despite existing ones
-     login: 'native', // If user authentication is handled natively in-app
+     login: 'embedded', // If user authentication is handled in-app
      support: 'legacy', // Set globally or locally; `"legacy"` or `undefined` will use iframe
      serverConfig: {
        timeout: 5000, // If using "legacy", use a short timeout to catch error


### PR DESCRIPTION
Summary:

After internal discussion, we decided to change the string value for determining login handled by the app itself as "embedded", rather than "native".

Details:

The literal string value for the interface declaration has been changed, but no code actually references this value directly, so no other change is required.