### PR TITLE
[CI/CD] Junit reporter for jest tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 samples/_static/js/*.js*
 tests/**/app/index.js*
 tests/**/ie11/autoscript.js*
+reports/*
 *.copy.*
 *.pem
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "fake-indexeddb": "^3.0.0",
     "husky": "^4.2.5",
     "jest": "^26.0.1",
+    "jest-junit": "^12.0.0",
     "jest-canvas-mock": "^2.2.0",
     "jest-dev-server": "^4.3.0",
     "jest-environment-jsdom": "^26.0.1",

--- a/tests/jest.basic.config.js
+++ b/tests/jest.basic.config.js
@@ -16,6 +16,7 @@ module.exports = {
     },
   },
   preset: 'ts-jest',
+  reporters: ['default', ['jest-junit', { outputDirectory: `reports/${Date.now()}`, suiteNameTemplate: "{filename}", classNameTemplate: "{filename}", includeConsoleOutput: true} ]],
   rootDir: '../',
   setupFiles: ['jest-canvas-mock'],
 };

--- a/tests/jest.e2e.config.js
+++ b/tests/jest.e2e.config.js
@@ -18,6 +18,7 @@ module.exports = {
     },
   },
   preset: 'ts-jest',
+  reporters: ['default', ['jest-junit', { outputDirectory: `reports/${Date.now()}`, suiteNameTemplate: "{filename}", classNameTemplate: "{filename}", includeConsoleOutput: true} ]],
   testTimeout: 20 * 1000, // 20 seconds (must be more than the setup-and-go.ts timeout)
   rootDir: '../',
 };


### PR DESCRIPTION
* Added jest-juint reports, so that we can track results in Jenkins builds. 

**Note:** The reports are generated under `reports/${Date.now()}` directory so that we can run and preserve all reports (unit, integration and e2e...). Take a look [here](https://jenkins.petrov.ca/view/JS/job/JS-Core-SDK/40/testReport/) for an example test report after successful build. 