### PR TITLE
feat: Allow custom tree in centralised UI

### DIFF
--- a/src/oauth2-client/index.ts
+++ b/src/oauth2-client/index.ts
@@ -15,6 +15,7 @@ import { StringDict } from '../shared/interfaces';
 import { Noop } from '../shared/types';
 import TokenStorage from '../token-storage';
 import { isOkOr4xx } from '../util/http';
+import middlewareWrapper from '../util/middleware';
 import PKCE from '../util/pkce';
 import { withTimeout } from '../util/timeout';
 import { getEndpointPath, resolve, stringify } from '../util/url';
@@ -25,7 +26,6 @@ import {
   GetOAuth2TokensOptions,
   OAuth2Tokens,
 } from './interfaces';
-import middlewareWrapper from '../util/middleware';
 
 const allowedErrors = {
   // AM error for consent requirement
@@ -53,6 +53,7 @@ abstract class OAuth2Client {
       response_type: options.responseType,
       scope,
       state: options.state,
+      service: options.service,
     };
 
     if (options.verifier) {

--- a/src/oauth2-client/interfaces.ts
+++ b/src/oauth2-client/interfaces.ts
@@ -36,6 +36,7 @@ interface GetAuthorizationUrlOptions extends ConfigOptions {
   responseType: ResponseType;
   state?: string;
   verifier?: string;
+  service?: string;
 }
 
 /**

--- a/src/token-manager/index.ts
+++ b/src/token-manager/index.ts
@@ -20,6 +20,7 @@ interface GetTokensOptions extends ConfigOptions {
   forceRenew?: boolean;
   login?: 'embedded' | 'redirect' | undefined;
   query?: StringDict<string>;
+  tree?: string;
 }
 
 abstract class TokenManager {
@@ -115,7 +116,13 @@ abstract class TokenManager {
      */
     const verifier = PKCE.createVerifier();
     const state = PKCE.createState();
-    const authorizeUrlOptions = { ...options, responseType: ResponseType.Code, state, verifier };
+    const authorizeUrlOptions = {
+      ...options,
+      responseType: ResponseType.Code,
+      state,
+      verifier,
+      service: options?.tree,
+    };
     const authorizeUrl = await OAuth2Client.createAuthorizeUrl(authorizeUrlOptions);
 
     /**


### PR DESCRIPTION
When calling getTokens with login: redirect, this change allows
you to set the tree/journey.

```
const tokens = await forgerock.TokenManager.getTokens({
  forceRenew: true,
  login: 'redirect',
  tree: 'CustomTree', // new
});
```