### PR TITLE
Feat (acr_values/authorize): pass query properties through to authorize call

### DIFF
--- a/src/oauth2-client/index.ts
+++ b/src/oauth2-client/index.ts
@@ -48,6 +48,7 @@ abstract class OAuth2Client {
     const { clientId, redirectUri, scope } = Config.get(options);
 
     const requestParams: StringDict<string | undefined> = {
+      ...options.query,
       client_id: clientId,
       redirect_uri: redirectUri,
       response_type: options.responseType,

--- a/src/oauth2-client/interfaces.ts
+++ b/src/oauth2-client/interfaces.ts
@@ -8,6 +8,7 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
+import { StringDict } from 'shared/interfaces';
 import { ConfigOptions } from '../config';
 import { ResponseType } from './enums';
 
@@ -36,6 +37,7 @@ interface GetAuthorizationUrlOptions extends ConfigOptions {
   responseType: ResponseType;
   state?: string;
   verifier?: string;
+  query?: StringDict<string>;
 }
 
 /**

--- a/tests/e2e/app/authn-basic/autoscript.js
+++ b/tests/e2e/app/authn-basic/autoscript.js
@@ -18,8 +18,8 @@
   const url = new URL(window.location.href);
   const amUrl = url.searchParams.get('amUrl') || 'https://auth.example.com:9443/am';
   const realmPath = url.searchParams.get('realmPath') || 'root';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'UsernamePassword';
 
   console.log('Configure the SDK');

--- a/tests/e2e/app/authn-central-login/autoscript.js
+++ b/tests/e2e/app/authn-central-login/autoscript.js
@@ -18,11 +18,12 @@
   const url = new URL(window.location.href);
   const amUrl = url.searchParams.get('amUrl') || 'https://auth.example.com:9443/am';
   const code = url.searchParams.get('code') || '';
-  const clientId = url.searchParams.get('clientId') || 'WebOAuthClient';
+  const clientId = url.searchParams.get('clientId') || 'CentralLoginOAuthClient';
   const realmPath = url.searchParams.get('realmPath') || 'root';
   const scope = url.searchParams.get('scope') || 'openid profile me.read';
   const state = url.searchParams.get('state') || '';
   const support = url.searchParams.get('support') || 'legacy';
+  const acr_values = url.searchParams.get('acr') || 'SpecificTree';
 
   console.log('Configure the SDK');
   forgerock.Config.set({
@@ -49,7 +50,7 @@
       .from([1])
       .pipe(
         rxMap(() => {
-          console.log('Set cookie');
+          console.log('Set mock cookie to represent existing session');
           document.cookie = 'iPlanetDirectoryPro=abcd1234; domain=example.com; path=/';
           if (code && state) {
             window.sessionStorage.setItem(
@@ -64,9 +65,9 @@
           console.log('Get OAuth tokens');
           let tokens;
           if (code && state) {
-            tokens = forgerock.TokenManager.getTokens({ query: { code, state } });
+            tokens = forgerock.TokenManager.getTokens({ query: { code, state, acr_values } });
           } else {
-            tokens = forgerock.TokenManager.getTokens();
+            tokens = forgerock.TokenManager.getTokens({ query: { acr_values } });
           }
           return tokens;
         }),

--- a/tests/e2e/app/authn-device-profile/autoscript.js
+++ b/tests/e2e/app/authn-device-profile/autoscript.js
@@ -18,8 +18,8 @@
   const url = new URL(window.location.href);
   const amUrl = url.searchParams.get('amUrl') || 'https://auth.example.com:9443/am';
   const realmPath = url.searchParams.get('realmPath') || 'root';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'DeviceProfileCallbackTest';
 
   console.log('Configure the SDK');

--- a/tests/e2e/app/authn-email-suspend/autoscript.js
+++ b/tests/e2e/app/authn-email-suspend/autoscript.js
@@ -20,7 +20,7 @@
   const amUrl = url.searchParams.get('amUrl') || 'https://auth.example.com:9443/am';
   const realmPath = url.searchParams.get('realmPath') || 'root';
   const tree = url.searchParams.get('tree') || 'LoginWithEmail';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
+  const un = url.searchParams.get('un') || 'sdkuser';
 
   console.log('Configure the SDK');
   forgerock.Config.set({

--- a/tests/e2e/app/authn-no-session/autoscript.js
+++ b/tests/e2e/app/authn-no-session/autoscript.js
@@ -18,8 +18,8 @@
   const url = new URL(window.location.href);
   const amUrl = url.searchParams.get('amUrl') || 'https://auth.example.com:9443/am';
   const realmPath = url.searchParams.get('realmPath') || 'root';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'UsernamePassword';
 
   console.log('Configure the SDK');

--- a/tests/e2e/app/authn-oauth/autoscript.js
+++ b/tests/e2e/app/authn-oauth/autoscript.js
@@ -20,8 +20,8 @@
   const clientId = url.searchParams.get('clientId') || 'WebOAuthClient';
   const realmPath = url.searchParams.get('realmPath') || 'root';
   const scope = url.searchParams.get('scope') || 'openid profile me.read';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'UsernamePassword';
 
   console.log('Configure the SDK');
@@ -101,7 +101,7 @@
       rxMergeMap(
         (tokens) => {
           console.log('Force renew OAuth tokens');
-          return forgerock.TokenManager.getTokens({ forceRenew: true });;
+          return forgerock.TokenManager.getTokens({ forceRenew: true });
         },
         (oldTokens, newTokens) => {
           if (oldTokens.accessToken !== newTokens.accessToken) {

--- a/tests/e2e/app/authn-platform/autoscript.js
+++ b/tests/e2e/app/authn-platform/autoscript.js
@@ -18,8 +18,8 @@
   const url = new URL(window.location.href);
   const amUrl = url.searchParams.get('amUrl') || 'https://auth.example.com:9443/am';
   const realmPath = url.searchParams.get('realmPath') || 'root';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'PlatformUsernamePasswordTest';
 
   console.log('Configure the SDK');
@@ -46,7 +46,7 @@
         rxMergeMap((step) => {
           console.log('Set values on auth tree callbacks for validation only');
           const unCb = step.getCallbackOfType('ValidatedCreateUsernameCallback');
-          // In order to pass validation (with existing username in AM), 
+          // In order to pass validation (with existing username in AM),
           // the valid-username policy needs to be removed from the IDM managed user object
           unCb.setName(un);
           unCb.setValidateOnly(true);

--- a/tests/e2e/app/authn-second-factor/autoscript.js
+++ b/tests/e2e/app/authn-second-factor/autoscript.js
@@ -19,8 +19,8 @@
 
   const amUrl = url.searchParams.get('amUrl') || 'https://auth.example.com:9443/am';
   const realmPath = url.searchParams.get('realmPath') || 'root';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'SecondFactor';
 
   console.log('Configure the SDK');

--- a/tests/e2e/app/authn-webauthn/autoscript.js
+++ b/tests/e2e/app/authn-webauthn/autoscript.js
@@ -18,8 +18,8 @@
   const url = new URL(window.location.href);
   const amUrl = url.searchParams.get('amUrl') || 'https://auth.example.com:9443/am';
   const realmPath = url.searchParams.get('realmPath') || 'root';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'PasswordlessWebAuthn';
 
   console.log('Configure the SDK');

--- a/tests/e2e/app/authz-tree-basic/autoscript.js
+++ b/tests/e2e/app/authz-tree-basic/autoscript.js
@@ -21,8 +21,8 @@
   const igUrl = url.searchParams.get('igUrl'); // only use when testing against IG on different host
   const resourceOrigin =
     url.searchParams.get('resourceOrigin') || 'https://api.example.com:9443/resource';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'UsernamePassword';
 
   console.log('Configure the SDK');

--- a/tests/e2e/app/authz-tree-oauth/autoscript.js
+++ b/tests/e2e/app/authz-tree-oauth/autoscript.js
@@ -23,8 +23,8 @@
   const resourceOrigin =
     url.searchParams.get('resourceOrigin') || 'https://api.example.com:9443/resource';
   const scope = url.searchParams.get('scope') || 'openid profile me.read';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'UsernamePassword';
 
   console.log('Configure the SDK');

--- a/tests/e2e/app/authz-txn-basic/autoscript.js
+++ b/tests/e2e/app/authz-txn-basic/autoscript.js
@@ -21,8 +21,8 @@
   const igUrl = url.searchParams.get('igUrl'); // only use when testing against IG on different host
   const resourceOrigin =
     url.searchParams.get('resourceOrigin') || 'https://api.example.com:9443/resource';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'UsernamePassword';
 
   console.log('Configure the SDK');

--- a/tests/e2e/app/authz-txn-oauth/autoscript.js
+++ b/tests/e2e/app/authz-txn-oauth/autoscript.js
@@ -23,8 +23,8 @@
   const resourceOrigin =
     url.searchParams.get('resourceOrigin') || 'https://api.example.com:9443/resource';
   const scope = url.searchParams.get('scope') || 'openid profile me.read';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'UsernamePassword';
 
   console.log('Configure the SDK');

--- a/tests/e2e/app/config-custom-paths/autoscript.js
+++ b/tests/e2e/app/config-custom-paths/autoscript.js
@@ -20,8 +20,8 @@
   const clientId = url.searchParams.get('clientId') || 'WebOAuthClient';
   const realmPath = url.searchParams.get('realmPath') || 'root';
   const scope = url.searchParams.get('scope') || 'openid profile me.read';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'UsernamePassword';
 
   console.log('Configure the SDK');

--- a/tests/e2e/app/config-request-middleware/autoscript.js
+++ b/tests/e2e/app/config-request-middleware/autoscript.js
@@ -20,8 +20,8 @@
   const clientId = url.searchParams.get('clientId') || 'WebOAuthClient';
   const realmPath = url.searchParams.get('realmPath') || 'root';
   const scope = url.searchParams.get('scope') || 'openid profile me.read';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'UsernamePassword';
 
   console.log('Configure the SDK');

--- a/tests/e2e/app/config-token-storage/autoscript.js
+++ b/tests/e2e/app/config-token-storage/autoscript.js
@@ -20,8 +20,8 @@
   const clientId = url.searchParams.get('clientId') || 'WebOAuthClient';
   const realmPath = url.searchParams.get('realmPath') || 'root';
   const scope = url.searchParams.get('scope') || 'openid profile me.read';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'UsernamePassword';
   let tokenStore = url.searchParams.get('tokenStore') || 'sessionStorage';
   let inMemoryTokens;

--- a/tests/e2e/app/ie11/index.js
+++ b/tests/e2e/app/ie11/index.js
@@ -64,7 +64,7 @@ if (!window.crypto && window.msCrypto) {
  * Configure your user, your base environment config, registration tree and login tree
  */
 const un = 'f9022889-4452-48a0-aa94-182436645551';
-const pw = 'ieH034K&-zlwqh3V_';
+const pw = 'password';
 const email = 'sally.tester@me.com';
 const loginTree = 'Login'; // Login tree after registration
 

--- a/tests/e2e/app/misc-callbacks/autoscript.js
+++ b/tests/e2e/app/misc-callbacks/autoscript.js
@@ -18,8 +18,8 @@
   const url = new URL(window.location.href);
   const amUrl = url.searchParams.get('amUrl') || 'https://auth.example.com:9443/am';
   const realmPath = url.searchParams.get('realmPath') || 'root';
-  const un = url.searchParams.get('un') || '57a5b4e4-6999-4b45-bf86-a4f2e5d4b629';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const un = url.searchParams.get('un') || 'sdkuser';
+  const pw = url.searchParams.get('pw') || 'password';
   const tree = url.searchParams.get('tree') || 'MiscCallbacks';
 
   console.log('Configure the SDK');

--- a/tests/e2e/app/register-basic/autoscript.js
+++ b/tests/e2e/app/register-basic/autoscript.js
@@ -21,7 +21,7 @@
   const realmPath = url.searchParams.get('realmPath') || 'root';
   const tree = url.searchParams.get('tree') || 'Registration';
   const un = url.searchParams.get('un') || 'f9022889-4452-48a0-aa94-182436645551';
-  const pw = url.searchParams.get('pw') || 'ieH034K&-zlwqh3V_';
+  const pw = url.searchParams.get('pw') || 'password';
   const email = url.searchParams.get('email') || 'sally.tester@me.com';
 
   console.log('Configure the SDK');

--- a/tests/e2e/server/routes.auth.mjs
+++ b/tests/e2e/server/routes.auth.mjs
@@ -225,6 +225,13 @@ export default function (app) {
   });
 
   app.get(authPaths.authorize, wait, async (req, res) => {
+    // Detect if Central Login to enforce ACR value presence
+    if (
+      req.query.client_id === 'CentralLoginOAuthClient' &&
+      req.query.acr_values !== 'SpecificTree'
+    ) {
+      return res.status(400).json({ message: 'acr_values did not match "SpecificTree"' });
+    }
     if (req.cookies.iPlanetDirectoryPro) {
       const url = new URL(`${req.query.redirect_uri}`);
       url.searchParams.set('client_id', 'bar');


### PR DESCRIPTION
**Summary:**

This allows for the usage of `acr_values` in order to specify a tree when calling the authorize endpoint.

**Details:**

Pass `query` object properties from the  `options` object in `getTokens` through to the authorize call as query parameters. This allows the use of ACR Values to be used to call specific trees.

**Notes:**

There are a lot of test file changes, but it's just the changing of fallback username and password values to align with the test automation's configuration object and its test users.

Relevant file changes to feature:

- https://github.com/ForgeRock/forgerock-javascript-sdk/pull/106/files#diff-92cd59f4227ad81ad8a7bddc61f9b5396662a6720247007d545ee1da7c7e0b1a
- https://github.com/ForgeRock/forgerock-javascript-sdk/pull/106/files#diff-253bb1127ccf96479910d15d3b8c63e6d9152b65ddfa84ec676b9c0f3302d9a8