### PR TITLE
feat (social-login): support Apple Sign In

### DIFF
--- a/tests/e2e/app/authn-social-login-idm/autoscript.js
+++ b/tests/e2e/app/authn-social-login-idm/autoscript.js
@@ -22,11 +22,12 @@
   const provider = url.searchParams.get('provider') || 'google';
   const code = url.searchParams.get('code');
   const state = url.searchParams.get('state');
+  const form_post_entry = url.searchParams.get('form_post_entry');
 
   console.log('Initiate first step with `undefined`');
   // Wrapping in setTimeout to give the test time to bind listener to console.log
   setTimeout(function () {
-    if (code && state) {
+    if ((code && state) || form_post_entry) {
       // Below three lines are needed for automation only
       const returnParamsString = window.localStorage.getItem('returnParams');
       window.localStorage.removeItem('returnParams');


### PR DESCRIPTION
**Summary**

This adds the needed support for Apple Sign In and its requirement for using a form POST, rather than a traditional GET redirect. This requires AM to support this form POST, and redirect back to the client web app.

**Details**

- Apple provider configuration requires AM to handle the form POST
- AM will process that form POST and encrypt and encode the data and do a GET redirect back to the client web app with the URL parameter of `form_post_entry`
- The SDK provides an existing `resume` that has been modified to include this `form_post_entry` along with the previously saved step and its `authId`