### PR TITLE
task (getTokens): encode data before storage and redirect

### DIFF
--- a/src/token-manager/index.ts
+++ b/src/token-manager/index.ts
@@ -104,7 +104,11 @@ abstract class TokenManager {
     if (options?.query?.code && options?.query?.state) {
       const storedString = window.sessionStorage.getItem(clientId as string);
       window.sessionStorage.removeItem(clientId as string);
-      const storedValues: { state: string; verifier: string } = JSON.parse(storedString as string);
+
+      const decodedAuthorizeUrlOptions = window.atob(storedString || '');
+      const storedValues: { state: string; verifier: string } = JSON.parse(
+        decodedAuthorizeUrlOptions as string,
+      );
 
       return await this.tokenExchange(options, storedValues);
     }
@@ -177,7 +181,8 @@ abstract class TokenManager {
       }
 
       // Since `login` is configured for "redirect", store authorize values and redirect
-      window.sessionStorage.setItem(clientId as string, JSON.stringify(authorizeUrlOptions));
+      const encodedAuthorizeUrlOptions = window.btoa(JSON.stringify(authorizeUrlOptions));
+      window.sessionStorage.setItem(clientId as string, encodedAuthorizeUrlOptions);
       return window.location.assign(authorizeUrl);
     }
 

--- a/tests/e2e/server/routes.auth.mjs
+++ b/tests/e2e/server/routes.auth.mjs
@@ -293,9 +293,26 @@ export default function (app) {
       url.searchParams.set('iss', `${AM_URL}/oauth2`);
       url.searchParams.set('state', req.query.state);
       res.redirect(url);
+    } else if (req.headers.accept.includes('html')) {
+      const url = new URL(`${req.protocol}://${req.headers.host}/login`);
+      url.searchParams.set('client_id', req.query.client_id);
+      url.searchParams.set('acr_values', req.query.acr_values);
+      url.searchParams.set('redirect_uri', req.query.redirect_uri);
+      url.searchParams.set('state', req.query.state);
+      res.redirect(url);
     } else {
-      res.redirect('/login');
+      res.status(401).send('Unauthorized');
     }
+  });
+
+  app.get('/login', async (req, res) => {
+    res.cookie('iPlanetDirectoryPro', 'abcd1234', { domain: 'example.com' });
+    const url = new URL(`${req.protocol}://${req.headers.host}${authPaths.authorize[1]}`);
+    url.searchParams.set('client_id', req.query.client_id);
+    url.searchParams.set('acr_values', req.query.acr_values);
+    url.searchParams.set('redirect_uri', req.query.redirect_uri);
+    url.searchParams.set('state', req.query.state);
+    res.redirect(url);
   });
 
   app.get('/callback', async (req, res) => {
@@ -334,6 +351,7 @@ export default function (app) {
           res.status(406).send('Middleware header is missing.');
         }
       } else {
+        res.clearCookie('iPlanetDirectoryPro', { domain: 'example.com', path: '/' });
         res.status(204).send();
       }
     }

--- a/tests/e2e/suites/authn-central-login.test.ts
+++ b/tests/e2e/suites/authn-central-login.test.ts
@@ -61,6 +61,29 @@ describe('Test OAuth login flow', () => {
     });
 
     // eslint-disable-next-line
+    it(`should full redirect for login to request auth code, then token exchange with ${browserType}`, async (done) => {
+      try {
+        const { browser, messageArray, networkArray } = await setupAndGo(
+          browserType,
+          'authn-central-login/?support=modern&preAuthenticated=false',
+        );
+
+        // Test assertions
+        // Test log messages
+        expect(messageArray.includes('OAuth authorization successful')).toBe(true);
+        expect(messageArray.includes('Test script complete')).toBe(true);
+        // Test network requests
+        expect(networkArray.includes('/am/oauth2/realms/root/authorize, fetch')).toBe(true);
+        expect(networkArray.includes('/am/oauth2/realms/root/access_token, fetch')).toBe(true);
+
+        await browser.close();
+        done();
+      } catch (error) {
+        done(error);
+      }
+    });
+
+    // eslint-disable-next-line
     it(`should successfully take code & state params for token exchange with ${browserType}`, async (done) => {
       try {
         const { browser, messageArray, networkArray } = await setupAndGo(


### PR DESCRIPTION
Summary:

Encode data before storing in `sessionStorage` when fully redirecting to `/authorize` URL.

Details:

- base64 encode before storage and after retrieval
- write e2e tests coverage for full redirect