### PR TITLE
(docs): Sdks-1416/create-pr-template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+# JIRA Ticket
+
+Please link jira ticket here
+
+# Description
+
+# Type of Change
+
+Please Delete options that are not relevant
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+# Definition of Done
+
+Check all that apply
+
+- [ ] Acceptance criteria is met.
+- [ ] All tasks listed in the user story have been completed.
+- [ ] Coded to standards. - [ ] Code peer-reviewed. - [ ] Ensure backward compatibility (special attention).
+- [ ] API reference docs is updated.
+- [ ] Unit tests are written.
+- [ ] Integration tests are written.
+- [ ] e2e tests are written.
+- [ ] CI build passing on the feature branch.
+- [ ] Functional spec is written/updated - [ ] contains example code snippets.
+- [ ] Change log updated.
+- [ ] Documentation story is created and tracked.
+- [ ] UI is completed or ticket is created.
+- [ ] Demo to PO and team.
+- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).
+
+## Documentation
+
+- [ ] Acceptance criteria met
+- [ ] Spell-check run
+- [ ] Peer reviewed
+- [ ] Proofread


### PR DESCRIPTION
Create a pull request template for future PR's.

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository 

Documentation states that adding this file to the .github/ folder should make it so the template is used on PR's. I'm not sure if it would show up in this PR, or if we just have to hope that it shows up after its merged.

Feedback on what we want in this is welcome.

https://bugster.forgerock.org/jira/browse/SDKS-1416