### PR TITLE
fix(ci): add workflow dispatch option and trigger on publish instead

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Publish Package to npmjs & github
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch:
 jobs:
   npm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# JIRA Ticket

fixing #146 which just didn't trigger the workflow, adding option to manually trigger.

# Description

# Type of Change

Please Delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
It appears that the workflow call that creates the release may just emit a "publish" event. So we are trying that. Worst case scenario is i just manually publish again.

# Definition of Done

Check all that apply

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Code peer-reviewed.
- [ ] Ensure backward compatibility (special attention).
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] CI build passing on the feature branch.
- [ ] Functional spec is written/updated
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] UI is completed or ticket is created.
- [ ] Demo to PO and team.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).

## Documentation

- [ ] Acceptance criteria met
- [ ] Spell-check run
- [ ] Peer reviewed
- [ ] Proofread
