### PR TITLE
ci: nx-affected-fix

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -5,7 +5,7 @@
     "default": {
       "runner": "@nrwl/nx-cloud",
       "options": {
-        "cacheableOperations": ["build", "test", "lint", "package", "prepare", "e2e"],
+        "cacheableOperations": ["build", "test", "lint", "package", "prepare", "e2e", "version"],
         "useDaemonProcess": true,
         "accessToken": "NzU3MWE3MjgtOWRiZi00ZDczLWI4YWYtMDI5NThmNTRkNDc1fHJlYWQtd3JpdGU="
       }


### PR DESCRIPTION
the affected commands require the `version` target to be a cacheable
operation in the pipeline

https://nx.app/runs/bXFJ7UcofMQ to see it working