### PR TITLE
Fixed comment for PollingWaitCallback.getWaitTime().

### DIFF
--- a/packages/javascript-sdk/src/fr-auth/callbacks/polling-wait-callback.ts
+++ b/packages/javascript-sdk/src/fr-auth/callbacks/polling-wait-callback.ts
@@ -30,7 +30,7 @@ class PollingWaitCallback extends FRCallback {
   }
 
   /**
-   * Gets the polling interval in seconds.
+   * Gets the polling interval in milliseconds.
    */
   public getWaitTime(): number {
     return Number(this.getOutputByName<number>('waitTime', 0));


### PR DESCRIPTION
# Description

The comment for `PollingWaitCallback.getWaitTime()` is wrong (it returns the time in milliseconds, not seconds), so this PR fixes that.

# Type of Change

Please Delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I looked at the docs for the Android SDK, and [it says milliseconds](https://developer.forgerock.com/sdks/android/api-reference/forgerock-auth/org/forgerock/android/auth/callback/PollingWaitCallback.html), and then I looked at the response I got from ForgeRock when doing `advanceJourney`, and it was in milliseconds. 

# Definition of Done

Check all that apply

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Code peer-reviewed.
- [ ] Ensure backward compatibility (special attention).
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] CI build passing on the feature branch.
- [ ] Functional spec is written/updated
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] UI is completed or ticket is created.
- [ ] Demo to PO and team.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).

## Documentation

- [ ] Acceptance criteria met
- [ ] Spell-check run
- [ ] Peer reviewed
- [ ] Proofread