### PR TITLE
fix(javascript-sdk): remove-support-property

### DIFF
--- a/e2e/autoscript-apps/src/config-request-middleware/autoscript.ts
+++ b/e2e/autoscript-apps/src/config-request-middleware/autoscript.ts
@@ -39,11 +39,6 @@ function autoscript() {
           break;
         case 'AUTHORIZE':
           req.url.searchParams.set('authorize-middleware', 'authorization');
-          if (support === 'modern') {
-            req.init.headers = {
-              'x-authorize-middleware': 'authorization',
-            };
-          }
           break;
         case 'EXCHANGE_TOKEN':
           req.url.searchParams.set('exchange-token-middleware', 'exchange-token');
@@ -83,8 +78,7 @@ function autoscript() {
     // options call that is made by the modern call.
     // The api server will respond with a 200 so that the
     // preflight and actual request successfull resolve
-    redirectUri:
-      support === 'modern' ? `https://auth.example.com:9443/callback/` : `${url.origin}/_callback/`,
+    redirectUri: `${url.origin}/_callback/`,
     realmPath,
     scope,
     serverConfig: {
@@ -119,8 +113,6 @@ function autoscript() {
           console.log('Get OAuth tokens');
           const configObj = {
             ...(setMiddleware === 'atCallSite' ? { middleware } : null),
-            ...(support === 'modern' ? { realmPath: 'middleware-modern' } : null),
-            support,
           };
           const tokens = forgerock.TokenManager.getTokens(configObj);
 

--- a/e2e/autoscript-suites/src/suites/authn-central-login.test.ts
+++ b/e2e/autoscript-suites/src/suites/authn-central-login.test.ts
@@ -33,49 +33,6 @@ test.describe('Test OAuth login flow', () => {
     expect(networkArray.includes('/am/oauth2/realms/root/access_token, fetch')).toBe(true);
   });
 
-  // eslint-disable-next-line
-  test(`should use fetch to request auth code, then token exchange`, async ({
-    page,
-    browserName,
-  }) => {
-    const { messageArray, networkArray } = await setupAndGo(
-      page,
-      browserName,
-      'authn-central-login/',
-      { support: 'modern' },
-    );
-
-    // Test assertions
-    // Test log messages
-    expect(messageArray.includes('OAuth authorization successful')).toBe(true);
-    expect(messageArray.includes('Test script complete')).toBe(true);
-    // Test network requests
-    expect(networkArray.includes('/am/oauth2/realms/root/authorize, fetch')).toBe(true);
-    expect(networkArray.includes('/am/oauth2/realms/root/access_token, fetch')).toBe(true);
-  });
-  test(`should full redirect for login to request auth code, then token exchange`, async ({
-    browserName,
-    page,
-  }) => {
-    // Disable Firefox as it reports a errant CORS error
-    if (browserName !== 'firefox') {
-      const { messageArray, networkArray } = await setupAndGo(
-        page,
-        browserName,
-        'authn-central-login/',
-        { support: 'modern', preAuthenticated: 'false' },
-      );
-
-      // Test assertions
-      // Test log messages
-      expect(messageArray.includes('OAuth authorization successful')).toBe(true);
-      expect(messageArray.includes('Test script complete')).toBe(true);
-      // Test network requests
-      expect(networkArray.includes('/am/oauth2/realms/root/authorize, fetch')).toBe(true);
-      expect(networkArray.includes('/am/oauth2/realms/root/access_token, fetch')).toBe(true);
-    }
-  });
-  // eslint-disable-next-line
   test(`should successfully take code & state params for token exchange with browser`, async ({
     page,
     browserName,

--- a/e2e/autoscript-suites/src/suites/config-request-middleware.test.ts
+++ b/e2e/autoscript-suites/src/suites/config-request-middleware.test.ts
@@ -49,21 +49,4 @@ test.describe('Test request middleware with login flow', () => {
     expect(messageArray.includes('OAuth endSession was not successful')).toBe(false);
     expect(messageArray.includes('OAuth revokeToken was not successful')).toBe(false);
   });
-  test(`Full login and "modern" for oauth using middleware`, async ({ page, browserName }) => {
-    const { messageArray } = await setupAndGo(page, browserName, 'config-request-middleware/', {
-      realmPath: 'middleware',
-      support: 'modern',
-    });
-    // Test assertions
-    // Test log messages
-    expect(messageArray.includes('Auth tree successfully completed')).toBe(true);
-    expect(messageArray.includes('OAuth login successful')).toBe(true);
-    expect(messageArray.includes('User info successfully responded')).toBe(true);
-    expect(messageArray.includes('Logout successful')).toBe(true);
-
-    // Test for absence of error logs for FRUser.logout
-    expect(messageArray.includes('Session logout was not successful')).toBe(false);
-    expect(messageArray.includes('OAuth endSession was not successful')).toBe(false);
-    expect(messageArray.includes('OAuth revokeToken was not successful')).toBe(false);
-  });
 });

--- a/packages/javascript-sdk/src/config/interfaces.ts
+++ b/packages/javascript-sdk/src/config/interfaces.ts
@@ -29,7 +29,6 @@ interface ConfigOptions {
   redirectUri?: string;
   scope?: string;
   serverConfig?: ServerConfig;
-  support?: 'modern' | 'legacy' | undefined;
   tokenStore?: TokenStoreObject | 'indexedDB' | 'sessionStorage' | 'localStorage';
   tree?: string;
   type?: string;

--- a/packages/javascript-sdk/tests/integration/oauth2-client.test.ts
+++ b/packages/javascript-sdk/tests/integration/oauth2-client.test.ts
@@ -14,7 +14,6 @@ jest.mock('../../src/config', () => {
           baseUrl: 'https://openam.example.com/am/',
           timeout: '3000',
         },
-        support: 'modern',
         realmPath: '/alpha',
       };
     },


### PR DESCRIPTION
BREAKING CHANGE: remove the ability to use 'modern' as a means of making calls. fetch complicates the auth process too much for the value it provides. we've opted to remove this support property, automatically defaulting to the iframe.

# JIRA Ticket

https://bugster.forgerock.org/jira/browse/SDKS-2330

# Description
remove the support property and remove tests that test, the modern fetch call. 

# Type of Change

Please Delete options that are not relevant

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
e2e's and not using modern at all.

# Definition of Done

Check all that apply

- [x] Acceptance criteria is met.
- [x] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Code peer-reviewed.
- [ ] Ensure backward compatibility (special attention).
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] CI build passing on the feature branch.
- [ ] Functional spec is written/updated
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] UI is completed or ticket is created.
- [ ] Demo to PO and team.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).

## Documentation

- [ ] Acceptance criteria met
- [ ] Spell-check run
- [ ] Peer reviewed
- [ ] Proofread
