### PR TITLE
feat(javascript-sdk): refactor authorize URL utilities for DaVinci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19741,14 +19741,14 @@
     },
     "packages/javascript-sdk": {
       "name": "@forgerock/javascript-sdk",
-      "version": "4.4.1-alpha.2",
+      "version": "4.4.2",
       "license": "MIT"
     },
     "packages/ping-protect": {
       "name": "@forgerock/ping-protect",
-      "version": "4.4.1-alpha.2",
+      "version": "4.4.2",
       "peerDependencies": {
-        "@forgerock/javascript-sdk": "4.4.1-alpha.2"
+        "@forgerock/javascript-sdk": "4.4.2"
       }
     },
     "packages/token-vault": {

--- a/packages/javascript-sdk/src/oauth2-client/state-pkce.ts
+++ b/packages/javascript-sdk/src/oauth2-client/state-pkce.ts
@@ -1,0 +1,57 @@
+import PKCE from '../util/pkce';
+import { GetAuthorizationUrlOptions } from './interfaces';
+
+function getStorageKey(clientId: string, prefix?: string) {
+  return `${prefix || 'FR-SDK'}-authflow-${clientId}`;
+}
+
+/**
+ * Generate and store PKCE values for later use
+ * @param { string } storageKey - Key to store authorization options in sessionStorage
+ * @param {GenerateAndStoreAuthUrlValues} options - Options for generating PKCE values
+ * @returns { state: string, verifier: string, GetAuthorizationUrlOptions }
+ */
+interface GenerateAndStoreAuthUrlValues extends GetAuthorizationUrlOptions {
+  clientId: string;
+  login?: 'redirect' | 'embedded';
+  prefix?: string;
+}
+
+export function generateAndStoreAuthUrlValues(options: GenerateAndStoreAuthUrlValues) {
+  const verifier = PKCE.createVerifier();
+  const state = PKCE.createState();
+  const storageKey = getStorageKey(options.clientId, options.prefix);
+
+  const authorizeUrlOptions = {
+    ...options,
+    state,
+    verifier,
+  };
+
+  if (options.login === 'redirect') {
+    // Since `login` is configured for "redirect", store authorize values and redirect
+    sessionStorage.setItem(storageKey, JSON.stringify(authorizeUrlOptions));
+  }
+
+  return { state, verifier, authorizeUrlOptions };
+}
+
+/**
+ * @function getStoredAuthUrlValues - Retrieve stored authorization options from sessionStorage
+ * @param { string } storageKey - Key to retrieve stored values from sessionStorage
+ * @returns { GetAuthorizationUrlOptions }
+ */
+export function getStoredAuthUrlValues(
+  clientId: string,
+  prefix?: string,
+): GetAuthorizationUrlOptions {
+  const storageKey = getStorageKey(clientId, prefix);
+  const storedString = sessionStorage.getItem(storageKey);
+  sessionStorage.removeItem(storageKey);
+
+  try {
+    return JSON.parse(storedString as string);
+  } catch (error) {
+    throw new Error('Stored values for Auth URL could not be parsed');
+  }
+}


### PR DESCRIPTION
# JIRA Ticket

[Jira SDKS-3183](https://bugster.forgerock.org/jira/browse/SDKS-3183)

# Description

This adjusts the internal logic of Token Manager and OAuthClient to provide a bit more reuse within the DaVinci client module. The main intention was to expose the generation and storing of the PKCE related values so that the DaVinci module could use them without the internally "knowing" how or where the values are stored.

# Type of Change

Please Delete options that are not relevant

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested manually using standard testing with SDK journey apps as well as the DaVinci module's prototype. Automation all passes without any change to tests.

# Definition of Done

Check all that apply

- [x] Acceptance criteria is met.
- [x] All tasks listed in the user story have been completed.
- [x] Coded to standards.
- [x] Code peer-reviewed.
- [x] Ensure backward compatibility (special attention).
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] CI build passing on the feature branch.
- [ ] Functional spec is written/updated
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] UI is completed or ticket is created.
- [ ] Demo to PO and team.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).

## Documentation

- [ ] Acceptance criteria met
- [ ] Spell-check run
- [ ] Peer reviewed
- [ ] Proofread
