### PR TITLE
fix(javascript-sdk): prioritize displayName for WebAuthn name attribute

### DIFF
--- a/.changeset/great-bobcats-fry.md
+++ b/.changeset/great-bobcats-fry.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/javascript-sdk': patch
+---
+
+In order to display a more user-friendly name when saving a WebAuthn/Passkey device to an account, we prioritized displayName over userName for assignment to the `name` property of the WebAuthn options object. This avoids the display of UUIDs for saved credentials.

--- a/e2e/autoscript-apps/src/authn-webauthn/autoscript.ts
+++ b/e2e/autoscript-apps/src/authn-webauthn/autoscript.ts
@@ -3,7 +3,8 @@
  *
  * autoscript.ts
  *
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2024 Ping Identity. All rights reserved.
+ *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
@@ -61,8 +62,8 @@ function autoscript() {
       rxDelay(delay),
       mergeMap((step) => {
         console.log('Choose Passwordless login');
-        const cb = step.getCallbackOfType('ChoiceCallback');
-        cb.setChoiceIndex(0);
+        const cb = step.getCallbackOfType('ConfirmationCallback');
+        cb.setOptionIndex(0);
         return forgerock.FRAuth.next(step);
       }),
       rxDelay(delay),
@@ -128,7 +129,7 @@ function autoscript() {
         // Needed for testing WebAuthn on Safari due to user event needed
         console.log('Click the continue button!');
         const continueBtn = document.querySelector('.continue-btn');
-        return rxjs.fromEvent(continueBtn, 'click');
+        return fromEvent(continueBtn, 'click');
       }),
       mergeMap(() => {
         console.log('Log back in with WebAuthn');

--- a/packages/javascript-sdk/src/fr-webauthn/index.ts
+++ b/packages/javascript-sdk/src/fr-webauthn/index.ts
@@ -3,7 +3,8 @@
  *
  * index.ts
  *
- * Copyright (c) 2020 ForgeRock. All rights reserved.
+ * Copyright (c) 2024 Ping Identity. All rights reserved.
+ *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
@@ -461,7 +462,7 @@ abstract class FRWebAuthn {
       user: {
         displayName: displayName || userName,
         id: Int8Array.from(userId.split('').map((c: string) => c.charCodeAt(0))),
-        name: userName,
+        name: displayName || userName,
       },
     };
   }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3473](https://pingidentity.atlassian.net/browse/SDKS-3473)

## Description

In order to display a more user-friendly name when saving a WebAuthn/Passkey device to an account, we prioritized displayName over userName for assignment to the `name` property of the WebAuthn options object. This avoids the display of UUIDs for saved credentials.
