### PR TITLE
fix: ping-protect-versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,13 +7,12 @@
     }
   ],
   "commit": false,
-  "fixed": [["@forgerock/javascript-sdk"]],
+  "fixed": [["@forgerock/javascript-sdk"], ["@forgerock/ping-protect"]],
   "linked": [],
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
   "ignore": [
-    "@forgerock/ping-protect",
     "@forgerock/token-vault",
     "autoscript-apps",
     "autoscript-suites",

--- a/.changeset/stupid-eagles-cross.md
+++ b/.changeset/stupid-eagles-cross.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/ping-protect': patch
+---
+
+fix the protect-package versioning. no functional changes to protect package, but allow more loose versioning on javascript-sdk

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,11 @@ jobs:
             ./dist/**
           retention-days: 30
 
+      # make sure we have a build.
+      - run: pnpm exec nx run-many -t build
+        env:
+          NX_CLOUD_DISTRIBUTED_EXECUTION: false
+
       - run: git status
       - name: publish
         uses: changesets/action@v1

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "nx affected --target=build",
     "clean": "shx rm -rf ./{coverage,dist,docs,node_modules,tmp}/ ./{packages,e2e}/*/{dist,node_modules}/ && git clean -fX -e \"!.env*,nx-cloud.env\"",
     "ci:release": "pnpm publish -r --no-git-checks && changeset tag",
-    "ci:version": "changeset version && pnpm install --no-frozen-lockfile && pnpm nx format:write",
+    "ci:version": "changeset version && pnpm install --no-frozen-lockfile && pnpm nx format:write --uncommitted",
     "changeset": "changeset",
     "commit": "git cz",
     "docs": "nx affected --target=typedoc",

--- a/packages/javascript-sdk/package.json
+++ b/packages/javascript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/javascript-sdk",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "ForgeRock JavaScript SDK",
   "author": "ForgeRock",
   "license": "MIT",

--- a/packages/ping-protect/package.json
+++ b/packages/ping-protect/package.json
@@ -20,6 +20,6 @@
   },
   "types": "./dist/index.ts.d.ts",
   "dependencies": {
-    "@forgerock/javascript-sdk": "workspace:*"
+    "@forgerock/javascript-sdk": "workspace:^"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,7 +351,7 @@ importers:
   packages/ping-protect:
     dependencies:
       '@forgerock/javascript-sdk':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../javascript-sdk
 
   packages/token-vault:


### PR DESCRIPTION
# JIRA Ticket
N/A

## Description
This is a publish to fix the versioning problem presented when using `ping-protect`. We are now using the ~^so that any minor will be picked up.

https://pnpm.io/workspaces#publishing-workspace-packages

shows a reference to how this is translated
