### PR TITLE
fix(package): remove invalid ./src/ export

### DIFF
--- a/.changeset/fix-src-package.md
+++ b/.changeset/fix-src-package.md
@@ -1,0 +1,5 @@
+---
+"@forgerock/javascript-sdk": patch
+---
+
+Remove invalid `./src/` export from package.json to fix parsing errors in strict Node environments.

--- a/packages/javascript-sdk/package.json
+++ b/packages/javascript-sdk/package.json
@@ -46,16 +46,6 @@
         "types": "./dist/*.d.cts",
         "default": "./dist/*.cjs"
       }
-    },
-    "./src/": {
-      "import": {
-        "types": "./dist/*.d.ts",
-        "default": "./dist/*.js"
-      },
-      "require": {
-        "types": "./dist/*.d.cts",
-        "default": "./dist/*.cjs"
-      }
     }
   },
   "type": "module",


### PR DESCRIPTION
## Description

The "./src/" entry in the exports field was invalid since folder exports must point to a directory (ending with "/"), not to file patterns.  This entry is also redundant with "./src/*" and caused errors when parsing package.json in strict environments (e.g. Node 16+).

Added a patch changeset.
