### PR TITLE
ci: update-publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,9 +78,7 @@ jobs:
           commit: 'chore: version-packages' # the commit message to use
           setupGitUser: true
         env:
-          HOME: ${{ github.workspace }} # See https://github.com/changesets/action/issues/147
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Publish previews to Stackblitz on PR
         if: steps.changesets.outputs.published == 'false'
@@ -101,6 +99,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
 
+      - name: Format published packages for Slack
+        if: steps.changesets.outputs.published == 'true'
+        id: format-packages
+        run: |
+          PACKAGES=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[] | ":package: *\(.name)* `\(.version)`"')
+          echo "formatted<<EOF" >> $GITHUB_OUTPUT
+          echo "$PACKAGES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Send GitHub Action data to a Slack workflow
         if: steps.changesets.outputs.published == 'true'
         uses: slackapi/slack-github-action@v2.1.1
@@ -109,7 +116,7 @@ jobs:
           webhook: ${{ env.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
-            publishedPackages: steps.changesets.outputs.publishedPackages
+            publishedPackages: ${{ steps.format-packages.outputs.formatted }}
 
       - name: Run code coverage
         uses: codecov/codecov-action@v5

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,1 @@
-link-workspace-packages=true
-strict-peer-dependencies=false
-save-workspace-protocol=rolling
-save-prefix=""
+registry=https://registry.npmjs.org/

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,8 @@ packages:
 catalog:
   '@reduxjs/toolkit': ^2.2.5
   immer: ^10.1.1
+
+link-workspace-packages: true
+strict-peer-dependencies: false
+save-workspace-protocol: rolling
+save-prefix: ''


### PR DESCRIPTION
# JIRA Ticket

N/A

## Description

Make changes to ci publishing so that it works with trusted publishing

- added npmrc that uses default registry url so token is not appended
- removed the github workspace
- formatted packages for slack message