### PR TITLE
fix(ping-protect): fixes type for PIProtect.start() options object

### DIFF
--- a/.changeset/brave-moose-run.md
+++ b/.changeset/brave-moose-run.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/ping-protect': patch
+---
+
+fixes the type of the options param in `PIProtect.start` so it better aligns with output from `PingOneProtectInitializeCallback.getConfig()` as defined in `javascript-sdk` (importantly it no longer expects `_type` and `_action` fields)

--- a/packages/ping-protect/src/lib/ping-protect.ts
+++ b/packages/ping-protect/src/lib/ping-protect.ts
@@ -27,7 +27,7 @@ export type InitParams = Omit<ProtectInitializeConfig, '_type' | '_action'>;
 declare global {
   interface Window {
     _pingOneSignals: {
-      init: (initParams?: ProtectInitializeConfig) => Promise<void>;
+      init: (initParams?: InitParams) => Promise<void>;
       getData: () => Promise<string>;
       pauseBehavioralData: () => void;
       resumeBehavioralData: () => void;
@@ -56,7 +56,7 @@ export abstract class PIProtect {
    * @param {InitParams} options - The init parameters
    * @returns {Promise<void>} - Returns a promise
    */
-  public static async start(options: ProtectInitializeConfig): Promise<void> {
+  public static async start(options: InitParams): Promise<void> {
     try {
       /*
        * Load the Ping Signals SDK


### PR DESCRIPTION
# JIRA Ticket

N/A

## Description

While working on a component to handle Ping One Protect using `@forgerock/javascript-sdk`, I found that after updating to the latest version of `@forgerock/ping-protect` (eg. `4.6.2`) I starting to see unexpected TypeScript errors when I attempted to pull Ping One config from a `PingOneProtectInitializeCallback` callback via `PingOneProtectInitializeCallback.getConfig()`. This is expected to return an object with the following type:
```typescript
declare class PingOneProtectInitializeCallback extends FRCallback {
    payload: Callback;
    /**
     * @param payload The raw payload returned by OpenAM
     */
    constructor(payload: Callback);
    /**
     * Get callback's initialization config settings
     */
    getConfig(): {
        behavioralDataCollection: boolean;
        disableTags: boolean;
        universalDeviceIdentification: boolean;
        consoleLogEnabled: boolean;
        deviceAttributesToIgnore: string[];
        customHost: string;
        lazyMetadata: boolean;
        deviceKeyRsyncIntervals: number;
        enableTrust: boolean;
        disableHub: boolean;
        agentPort?: number | undefined;
        agentTimeout?: number | undefined;
        agentIdentification?: boolean | undefined;
        envId: string;
    };
    setClientError(errorMessage: string): void;
}
```

This works fine in version `4.6.1` of `@forgerock/ping-protect`, however in `4.6.2`  when I attempt to pass the result of `PingOneProtectInitializeCallback.getConfig()` to `PIProtect.start(config)` I get a TypeScript error because `PIProtect.start()` is expecting the `_type` and `_action` fields. These fields are explicitly omitted in the `InitConfig` interface in `packages/ping-protect/src/lib/ping-protect.ts`.


```typescript
// Example code
const config = pingOneProtectInitializeCallback.getConfig();
await PIProtect.start(config);
```

Here's a screenshot of the TypeScript error from VS Code.

<img width="1057" height="303" alt="ping-one-protect-start" src="https://github.com/user-attachments/assets/6b4db6d1-2df2-49ed-9fe6-f1b4605edbe9" />

Full error in plain text:
```
Argument of type '{ behavioralDataCollection: boolean; disableTags: boolean; universalDeviceIdentification: boolean; consoleLogEnabled: boolean; deviceAttributesToIgnore: string[]; customHost: string; ... 7 more ...; envId: string; }' is not assignable to parameter of type 'ProtectInitializeConfig'.
  Type '{ behavioralDataCollection: boolean; disableTags: boolean; universalDeviceIdentification: boolean; consoleLogEnabled: boolean; deviceAttributesToIgnore: string[]; customHost: string; ... 7 more ...; envId: string; }' is missing the following properties from type 'ProtectInitializeConfig': _type, _action 
ts(2345)
```


### Did you add a changeset?

Yes a changeset has been included. I'm not sure if this is appropriate for a change like this (developer facing).