### PR TITLE
fix(ci): fix slack payload parsing in release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - run: pnpm exec nx affected -t build lint test docs e2e-ci
 
       - name: Publish previews to Stackblitz on PR
-        run: pnpm pkg-pr-new publish './packages/*' --packageManager=pnpm
+        run: pnpm pkg-pr-new publish './packages/*' --packageManager=pnpm  --pnpm
 
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -170,8 +170,9 @@ jobs:
         id: format-packages
         env:
           NPM_TAG: ${{ inputs.npm_tag }}
+          SNAPSHOT_TAG: ${{ inputs.snapshot_tag }}
         run: |
-          FORMATTED=$(jq -rs '.[] | ":package: *\(.name)* `\(.version)`"' packages/*/package.json)
+          FORMATTED=$(jq -rs --arg tag "$SNAPSHOT_TAG" '[.[] | select(.version | contains($tag))] | .[] | ":package: *\(.name)* `\(.version)`"' packages/*/package.json)
           PAYLOAD=$(jq -n --arg packages "$FORMATTED" --arg npmTag "$NPM_TAG" '{"npmTag": $npmTag, "publishedPackages": $packages}')
           echo "payload<<EOF" >> $GITHUB_OUTPUT
           echo "$PAYLOAD" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,12 +113,18 @@ jobs:
 
       - name: Send GitHub Action data to a Slack workflow
         if: steps.changesets.outputs.published == 'true'
+        id: slack-notify
         continue-on-error: true
         uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ env.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: ${{ steps.format-packages.outputs.payload }}
+
+      - name: Warn if Slack notification failed
+        if: steps.slack-notify.outcome == 'failure'
+        run: |
+          echo "::warning::Slack notification failed. Check the webhook URL and payload format."
 
       - name: Run code coverage
         uses: codecov/codecov-action@v5
@@ -159,14 +165,29 @@ jobs:
         id: npmpublish
         run: pnpm publish -r --tag ${{ inputs.npm_tag }} --no-git-checks --access ${{ inputs.npm_access }}
 
+      - name: Format published packages for Slack
+        if: steps.npmpublish.outcome == 'success'
+        id: format-packages
+        env:
+          NPM_TAG: ${{ inputs.npm_tag }}
+        run: |
+          FORMATTED=$(jq -rs '.[] | ":package: *\(.name)* `\(.version)`"' packages/*/package.json)
+          PAYLOAD=$(jq -n --arg packages "$FORMATTED" --arg npmTag "$NPM_TAG" '{"npmTag": $npmTag, "publishedPackages": $packages}')
+          echo "payload<<EOF" >> $GITHUB_OUTPUT
+          echo "$PAYLOAD" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Send GitHub Action data to a Slack workflow
         if: steps.npmpublish.outcome == 'success'
+        id: slack-notify-beta
         continue-on-error: true
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          payload-delimiter: '_'
           webhook: ${{ env.SLACK_WEBHOOK_URL_BETA }}
           webhook-type: webhook-trigger
-          payload: |
-            npmTag: "${{ inputs.npm_tag }}"
-            publishedPackages: ""
+          payload: ${{ steps.format-packages.outputs.payload }}
+
+      - name: Warn if Slack notification failed
+        if: steps.slack-notify-beta.outcome == 'failure'
+        run: |
+          echo "::warning::Slack beta notification failed. Check the webhook URL and payload format."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,21 +102,23 @@ jobs:
       - name: Format published packages for Slack
         if: steps.changesets.outputs.published == 'true'
         id: format-packages
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
-          PACKAGES=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[] | ":package: *\(.name)* `\(.version)`"')
-          echo "formatted<<EOF" >> $GITHUB_OUTPUT
-          echo "$PACKAGES" >> $GITHUB_OUTPUT
+          FORMATTED=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | ":package: *\(.name)* `\(.version)`"')
+          PAYLOAD=$(jq -n --arg packages "$FORMATTED" '{"publishedPackages": $packages}')
+          echo "payload<<EOF" >> $GITHUB_OUTPUT
+          echo "$PAYLOAD" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Send GitHub Action data to a Slack workflow
         if: steps.changesets.outputs.published == 'true'
+        continue-on-error: true
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          payload-delimiter: '_'
           webhook: ${{ env.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
-          payload: |
-            publishedPackages: ${{ steps.format-packages.outputs.formatted }}
+          payload: ${{ steps.format-packages.outputs.payload }}
 
       - name: Run code coverage
         uses: codecov/codecov-action@v5
@@ -159,6 +161,7 @@ jobs:
 
       - name: Send GitHub Action data to a Slack workflow
         if: steps.npmpublish.outcome == 'success'
+        continue-on-error: true
         uses: slackapi/slack-github-action@v2.1.1
         with:
           payload-delimiter: '_'

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "mkcert": "^3.2.0",
     "npm-cli-login": "^1.0.0",
     "nx": "20.3.3",
-    "pkg-pr-new": "^0.0.60",
+    "pkg-pr-new": "^0.0.63",
     "playwright": "1.47.2",
     "prettier": "^3.2.5",
     "pretty-quick": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,8 +191,8 @@ importers:
         specifier: 20.3.3
         version: 20.3.3(@swc-node/register@1.9.2(@swc/core@1.5.7(@swc/helpers@0.5.12))(@swc/types@0.1.7)(typescript@5.6.3))(@swc/core@1.5.7(@swc/helpers@0.5.12))
       pkg-pr-new:
-        specifier: ^0.0.60
-        version: 0.0.60
+        specifier: ^0.0.63
+        version: 0.0.63
       playwright:
         specifier: 1.47.2
         version: 1.47.2
@@ -349,28 +349,28 @@ packages:
       }
     engines: { node: '>=0.10.0' }
 
-  '@actions/core@1.11.1':
+  '@actions/core@3.0.0':
     resolution:
       {
-        integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==,
+        integrity: sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==,
       }
 
-  '@actions/exec@1.1.1':
+  '@actions/exec@3.0.0':
     resolution:
       {
-        integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==,
+        integrity: sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==,
       }
 
-  '@actions/http-client@2.2.3':
+  '@actions/http-client@4.0.0':
     resolution:
       {
-        integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==,
+        integrity: sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==,
       }
 
-  '@actions/io@1.1.3':
+  '@actions/io@3.0.2':
     resolution:
       {
-        integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==,
+        integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==,
       }
 
   '@adobe/css-tools@4.3.3':
@@ -2155,13 +2155,6 @@ packages:
         integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==,
       }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
-
-  '@fastify/busboy@2.1.1':
-    resolution:
-      {
-        integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==,
-      }
-    engines: { node: '>=14' }
 
   '@gerrit0/mini-shiki@1.24.4':
     resolution:
@@ -10161,10 +10154,10 @@ packages:
       }
     engines: { node: '>=14.16' }
 
-  pkg-pr-new@0.0.60:
+  pkg-pr-new@0.0.63:
     resolution:
       {
-        integrity: sha512-eblxPNSgv0AO18OrfpHq+YrNHfEqeePWWvlKkPvcHByddGsGDOK25z41C1RDjZ+K8zUHDk5IGN+6n0WZa4T2Pg==,
+        integrity: sha512-N4qfhiahmWVmUTKo//Bvb1FAKV7DwFcOjh8GT/aTh0YFSWRZwZp02afpNSohSs1z1jj0YOjU6Ff62iJ0AuHCfg==,
       }
     hasBin: true
 
@@ -12412,17 +12405,17 @@ packages:
         integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==,
       }
 
-  undici@5.29.0:
-    resolution:
-      {
-        integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==,
-      }
-    engines: { node: '>=14.0' }
-
   undici@6.19.2:
     resolution:
       {
         integrity: sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==,
+      }
+    engines: { node: '>=18.17' }
+
+  undici@6.23.0:
+    resolution:
+      {
+        integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==,
       }
     engines: { node: '>=18.17' }
 
@@ -13168,21 +13161,21 @@ packages:
 snapshots:
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
-  '@actions/core@1.11.1':
+  '@actions/core@3.0.0':
     dependencies:
-      '@actions/exec': 1.1.1
-      '@actions/http-client': 2.2.3
+      '@actions/exec': 3.0.0
+      '@actions/http-client': 4.0.0
 
-  '@actions/exec@1.1.1':
+  '@actions/exec@3.0.0':
     dependencies:
-      '@actions/io': 1.1.3
+      '@actions/io': 3.0.2
 
-  '@actions/http-client@2.2.3':
+  '@actions/http-client@4.0.0':
     dependencies:
       tunnel: 0.0.6
-      undici: 5.29.0
+      undici: 6.23.0
 
-  '@actions/io@1.1.3': {}
+  '@actions/io@3.0.2': {}
 
   '@adobe/css-tools@4.3.3': {}
 
@@ -14487,8 +14480,6 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.0': {}
-
-  '@fastify/busboy@2.1.1': {}
 
   '@gerrit0/mini-shiki@1.24.4':
     dependencies:
@@ -20125,9 +20116,9 @@ snapshots:
     dependencies:
       find-up: 6.3.0
 
-  pkg-pr-new@0.0.60:
+  pkg-pr-new@0.0.63:
     dependencies:
-      '@actions/core': 1.11.1
+      '@actions/core': 3.0.0
       '@jsdevtools/ez-spawn': 3.0.4
       '@octokit/action': 6.1.0
       ignore: 5.3.1
@@ -21512,11 +21503,9 @@ snapshots:
 
   undici-types@6.20.0: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
-
   undici@6.19.2: {}
+
+  undici@6.23.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 


### PR DESCRIPTION
## Summary
- **Fixed Slack payload parsing** that broke the last release CI run ([#411](https://github.com/ForgeRock/forgerock-javascript-sdk/actions/runs/19873730773)). The formatted multi-line mrkdwn text was interpolated raw into the YAML payload, causing `slackapi/slack-github-action` to fail with "Invalid input! Failed to parse contents of the provided payload."
- **Build a proper JSON payload via `jq -n --arg`** which correctly escapes newlines, asterisks, and backticks in package names/versions.
- **Use environment variables** for changesets output instead of direct `${{ }}` interpolation in `run:` blocks to prevent command injection.
- **Add `continue-on-error: true`** to both Slack notification steps so a webhook failure never blocks npm publishing or code coverage.

## Context
On the Dec 2 release (merge of changeset-release/master), the "Send GitHub Action data to a Slack workflow" step failed, which halted the job and caused code coverage to be skipped entirely.

## Test plan
- [ ] Trigger a snapshot release via `workflow_dispatch` and verify the Slack notification sends (or gracefully fails without blocking)
- [ ] On the next production release, confirm the formatted packages payload is valid JSON and the Slack message renders correctly