### PR TITLE
fix: prevent destructuring error when reading from stored values

### DIFF
--- a/packages/javascript-sdk/src/oauth2-client/state-pkce.ts
+++ b/packages/javascript-sdk/src/oauth2-client/state-pkce.ts
@@ -46,13 +46,14 @@ export function generateAndStoreAuthUrlValues(options: GenerateAndStoreAuthUrlVa
 
 /**
  * @function getStoredAuthUrlValues - Retrieve stored authorization options from sessionStorage
- * @param { string } storageKey - Key to retrieve stored values from sessionStorage
- * @returns { GetAuthorizationUrlOptions }
+ * @param { string } clientId - Client ID
+ * @param { string } [prefix] - Prefix for storage key
+ * @returns { GetAuthorizationUrlOptions | null }
  */
 export function getStoredAuthUrlValues(
   clientId: string,
   prefix?: string,
-): GetAuthorizationUrlOptions {
+): GetAuthorizationUrlOptions | null {
   const storageKey = getStorageKey(clientId, prefix);
   const storedString = sessionStorage.getItem(storageKey);
   sessionStorage.removeItem(storageKey);

--- a/packages/javascript-sdk/src/token-manager/index.ts
+++ b/packages/javascript-sdk/src/token-manager/index.ts
@@ -128,7 +128,7 @@ abstract class TokenManager {
      * and return acquired tokens
      */
     if (options?.query?.code && options?.query?.state) {
-      const { state, verifier } = getStoredAuthUrlValues(clientId, prefix);
+      const { state, verifier } = getStoredAuthUrlValues(clientId, prefix) ?? {};
 
       if (state === undefined || verifier === undefined) {
         throw new Error(


### PR DESCRIPTION
## Description

`getStoredAuthUrlValues` can sometimes return null (e.g when the item is not found in storage) and attempting to destructure the return value causes an uncaught runtime error.

Changes:
- default to empty object with nullish coallescing before destructuring
- update `getStoredAuthUrlValues` type definition to reflect actual return type

This ensures the proper error handling downstream, where `state` and `verifier` are checked for undefined values, works as intended rather than crashing on destructuring.
