### PR TITLE
fix: retrieve WebAuthn credentials inside try/catch OPENAM-26284

### DIFF
--- a/.changeset/fix-webauthn-cancel-error.md
+++ b/.changeset/fix-webauthn-cancel-error.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/javascript-sdk': patch
+---
+
+fix: move getAuthenticationCredential back inside try/catch so that WebAuthn cancellation errors (e.g. NotAllowedError) are written to the HiddenValueCallback before re-throwing

--- a/packages/javascript-sdk/src/fr-webauthn/fr-webauthn.test.ts
+++ b/packages/javascript-sdk/src/fr-webauthn/fr-webauthn.test.ts
@@ -8,7 +8,7 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
-import { WebAuthnStepType } from './enums';
+import { WebAuthnOutcome, WebAuthnStepType } from './enums';
 import FRWebAuthn from './index';
 import {
   webAuthnRegJSCallback653,
@@ -23,6 +23,7 @@ import {
   webAuthnAuthMetaCallback70StoredUsername,
   webAuthnAuthConditionalMetaCallback,
 } from './fr-webauthn.mock.data';
+import { CallbackType } from '../auth/enums';
 import FRStep from '../fr-auth/fr-step';
 import Config from '../config';
 
@@ -243,5 +244,64 @@ describe('Test FRWebAuthn class with Conditional UI', () => {
     expect(publicKey.allowCredentials![0].id).toBeInstanceOf(Int8Array);
     const idArray = publicKey.allowCredentials![0].id as Int8Array;
     expect(Array.from(idArray)).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe('Test FRWebAuthn class with cancellation error handling', () => {
+  beforeEach(() => {
+    Object.defineProperty(global.navigator, 'credentials', {
+      value: {
+        get: vi.fn(),
+        create: vi.fn(),
+      },
+      writable: true,
+    });
+    Object.defineProperty(window, 'PublicKeyCredential', {
+      value: {
+        // Mocked as supported so conditional mediation checks pass through to the credential call
+        isConditionalMediationAvailable: vi.fn().mockResolvedValue(true),
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should write NotAllowedError to HiddenValueCallback when user cancels conditional authentication', async () => {
+    const cancelError = new Error('The operation either timed out or was not allowed.');
+    cancelError.name = 'NotAllowedError';
+    vi.spyOn(navigator.credentials, 'get').mockRejectedValue(cancelError);
+
+    const step = new FRStep(webAuthnAuthConditionalMetaCallback as any);
+
+    await expect(FRWebAuthn.authenticate(step)).rejects.toMatchObject({
+      name: 'NotAllowedError',
+    });
+
+    const hiddenCallback = step.getCallbacksOfType(CallbackType.HiddenValueCallback)[0];
+    expect(hiddenCallback).toBeDefined();
+    expect(hiddenCallback.getInputValue()).toBe(
+      `${WebAuthnOutcome.Error}::NotAllowedError:The operation either timed out or was not allowed.`,
+    );
+  });
+
+  it('should write NotAllowedError to HiddenValueCallback when user cancels standard authentication', async () => {
+    const cancelError = new Error('The operation either timed out or was not allowed.');
+    cancelError.name = 'NotAllowedError';
+    vi.spyOn(navigator.credentials, 'get').mockRejectedValue(cancelError);
+
+    const step = new FRStep(webAuthnAuthMetaCallback70 as any);
+
+    await expect(FRWebAuthn.authenticate(step)).rejects.toMatchObject({
+      name: 'NotAllowedError',
+    });
+
+    const hiddenCallback = step.getCallbacksOfType(CallbackType.HiddenValueCallback)[0];
+    expect(hiddenCallback).toBeDefined();
+    expect(hiddenCallback.getInputValue()).toBe(
+      `${WebAuthnOutcome.Error}::NotAllowedError:The operation either timed out or was not allowed.`,
+    );
   });
 });

--- a/packages/javascript-sdk/src/fr-webauthn/index.ts
+++ b/packages/javascript-sdk/src/fr-webauthn/index.ts
@@ -199,6 +199,26 @@ abstract class FRWebAuthn {
         } else {
           throw new Error('No Credential found from Public Key');
         }
+        const credential: PublicKeyCredential | null = await this.getAuthenticationCredential(
+          optionsTransformer(options),
+        );
+        const outcome: ReturnType<typeof this.getAuthenticationOutcome> =
+          this.getAuthenticationOutcome(credential);
+
+        if (metadataCallback) {
+          const meta = metadataCallback.getOutputValue('data') as WebAuthnAuthenticationMetadata;
+          if (meta?.supportsJsonResponse && credential && 'authenticatorAttachment' in credential) {
+            hiddenCallback.setInputValue(
+              JSON.stringify({
+                authenticatorAttachment: credential.authenticatorAttachment,
+                legacyData: outcome,
+              }),
+            );
+            return step;
+          }
+        }
+        hiddenCallback.setInputValue(outcome);
+        return step;
       } catch (error) {
         if (!(error instanceof Error)) throw error;
         // NotSupportedError is a special case
@@ -209,27 +229,6 @@ abstract class FRWebAuthn {
         hiddenCallback.setInputValue(`${WebAuthnOutcome.Error}::${error.name}:${error.message}`);
         throw error;
       }
-
-      const credential: PublicKeyCredential | null = await this.getAuthenticationCredential(
-        optionsTransformer(options),
-      );
-      const outcome: ReturnType<typeof this.getAuthenticationOutcome> =
-        this.getAuthenticationOutcome(credential);
-
-      if (metadataCallback) {
-        const meta = metadataCallback.getOutputValue('data') as WebAuthnAuthenticationMetadata;
-        if (meta?.supportsJsonResponse && credential && 'authenticatorAttachment' in credential) {
-          hiddenCallback.setInputValue(
-            JSON.stringify({
-              authenticatorAttachment: credential.authenticatorAttachment,
-              legacyData: outcome,
-            }),
-          );
-          return step;
-        }
-      }
-      hiddenCallback.setInputValue(outcome);
-      return step;
     } else {
       const e = new Error('Incorrect callbacks for WebAuthn authentication');
       e.name = WebAuthnOutcomeType.DataError;


### PR DESCRIPTION
# JIRA Ticket

OPENAM-26284 This fixes an issue where errors were not being caught and reported to AM


## Description

In a previous restructure, getAuthenticationCredential was moved outside of the catch block which populates the HiddenValueCallback. This meant that errors would not be reported to AM.
