### PR TITLE
docs: update sample app links to correct sdk-sample-apps paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ ForgeRock provides these samples to help demonstrate SDK functionality/implement
 
 To try out the Ping SDK for JavaScript please look at one of our samples:
 
-- [**Embedded login - `samples/embedded-login`**](https://github.com/ForgeRock/sdk-sample-apps/blob/main/embedded-login/README.md)
+- [**Embedded login - `archived/javascript/embedded-login`**](https://github.com/ForgeRock/sdk-sample-apps/tree/main/archived/javascript/embedded-login)
 
-- [**Central login - `samples/central-login`**](https://github.com/ForgeRock/sdk-sample-apps/blob/main/central-login/README.md)
+- [**Central login - `archived/javascript/central-login-oidc`**](https://github.com/ForgeRock/sdk-sample-apps/tree/main/archived/javascript/central-login-oidc)
 
-- [**React Todo - `samples/reactjs-todo`**](https://github.com/ForgeRock/sdk-sample-apps/blob/main/reactjs-todo/README.md)
+- [**React Todo - `archived/javascript/reactjs-todo-journey-legacy`**](https://github.com/ForgeRock/sdk-sample-apps/tree/main/archived/javascript/reactjs-todo-journey-legacy)
 
-- [**Angular Todo - `samples/angular-todo`**](https://github.com/ForgeRock/sdk-sample-apps/blob/main/angular-todo/README.md)
+- [**Angular Todo - `archived/javascript/angular-todo`**](https://github.com/ForgeRock/sdk-sample-apps/tree/main/archived/javascript/angular-todo)
 
 <!------------------------------------------------------------------------------------------------------------------------------------>
 

--- a/packages/javascript-sdk/README.md
+++ b/packages/javascript-sdk/README.md
@@ -56,7 +56,7 @@ To try out the Ping SDK for JavaScript, perform these steps:
 
    See [Server configuration](https://docs.pingidentity.com/sdks/latest/sdks/tutorials/javascript/00_before-you-begin.html#server_configuration) in the Documentation.
 
-2. Clone this repo:
+2. Clone the sample apps repo:
 
    ```
    git clone https://github.com/ForgeRock/sdk-sample-apps.git
@@ -68,7 +68,7 @@ To try out the Ping SDK for JavaScript, perform these steps:
    npm install
    ```
 
-4. Open `javascript/embedded-login/.env.example` and edit the configuration values to match your server.
+4. Open `archived/javascript/embedded-login/.env.example` and edit the configuration values to match your server.
 
 5. Save the file as `.env` in the same folder.
 


### PR DESCRIPTION
## Summary

- Updated stale sample app links in `README.md` and `packages/javascript-sdk/README.md` to point to their correct locations in the [sdk-sample-apps](https://github.com/ForgeRock/sdk-sample-apps) repo
- All four samples (embedded login, central login, React Todo, Angular Todo) now point to archived paths since those are the ones that use `@forgerock/javascript-sdk`; the active samples have migrated to newer modular clients

## Test plan

- [x] Verify all four sample links in root `README.md` resolve correctly on GitHub
- [x] Verify the `.env.example` path in `packages/javascript-sdk/README.md` Getting Started steps resolves correctly