### PR TITLE
fix(ci): pin npm bump to v10 to match node 20 engine requirement

### DIFF
--- a/.github/actions/setup-publish/action.yml
+++ b/.github/actions/setup-publish/action.yml
@@ -21,9 +21,9 @@ runs:
         cache: 'pnpm' # package manager for caching
         registry-url: 'https://registry.npmjs.org'
 
-    # Update npm to latest for provenance
+    # Update npm to latest release compatible with our pinned Node version, for provenance
     - name: Update npm
-      run: npm install -g npm@latest
+      run: npm install -g npm@10
       shell: bash
 
     - name: Install dependencies from lockfile


### PR DESCRIPTION
  ## Summary

  CI publish workflow started failing on `develop` after last merge.

  `.github/actions/setup-publish/action.yml` runs `npm install -g npm@latest` to update npm for provenance
  signing, but npm just cut a new major (12.x) requiring `Node ^22.22.2 || ^24.15.0 || >=26.0.0`. Workflow
  pins Node via `.node-version` (currently `20`), so runner has Node 20.20.2 and install fails with
  `EBADENGINE`.

  ## Fix

  Pin the npm bump to `npm@10` (latest major still compatible with Node 20's engine range), instead of
  floating to `latest`.

  ## Notes / Risks

  - Pinning to a major still allows drift within `10.x` patches.
  - If Node bumped to 22+ later, revisit this pin.
  - Node 20 already bundles npm 10.8.2 with provenance support — the manual "Update npm" step may be
  redundant entirely. Left as-is for this fix, worth reconsidering separately.
